### PR TITLE
chore(flake/nixpkgs): `b47203b2` -> `cb19ae8a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1642238013,
-        "narHash": "sha256-MMW3dkmhj6UwtzhgSjmrlaZVqaGXaU1DpIIi65LMCg0=",
+        "lastModified": 1642866692,
+        "narHash": "sha256-plKaYrIfvZ27ZdfPIWG2v2tchZFtsRL4gNcst7DTBCs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b47203b28f5cf1efc4e3476ca8f333db3a2c3223",
+        "rev": "cb19ae8afe362b6c686ba271cd41c7b008071456",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                   |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`a3a799ca`](https://github.com/NixOS/nixpkgs/commit/a3a799ca59ee223b8349f80b1bed39c61590f035) | `mpd: remove unknown build options`                                              |
| [`78681c27`](https://github.com/NixOS/nixpkgs/commit/78681c277f1c7ddcdfec3719adda99791658c787) | `pcapc: 1.0.0 -> 1.0.1`                                                          |
| [`9970f3d5`](https://github.com/NixOS/nixpkgs/commit/9970f3d56e3f25c2426036f3e186d08ab6c59350) | `chromiumDev: 99.0.4818.0 -> 99.0.4840.0`                                        |
| [`1f7d88bb`](https://github.com/NixOS/nixpkgs/commit/1f7d88bba222e6cb297ae9da6b120db6cfba2c51) | `signal-desktop: 5.27.0 -> 5.27.1`                                               |
| [`992137e4`](https://github.com/NixOS/nixpkgs/commit/992137e4851a07187520e1e2a5150ca2fb8143c7) | `nitter: unstable-2021-12-31 -> unstable-2022-01-32`                             |
| [`b9e70dfa`](https://github.com/NixOS/nixpkgs/commit/b9e70dfa7f95ed227e9f460baebd286935e0cde7) | `nimPackages.jsony: init at 1.1.3`                                               |
| [`f88788ec`](https://github.com/NixOS/nixpkgs/commit/f88788ecd2af79caa1d96bd171e003157c373263) | `nncp: 8.1.0 -> 8.2.0`                                                           |
| [`e9b691ea`](https://github.com/NixOS/nixpkgs/commit/e9b691ea5d3eb07aa25256563f37a45d4fcdb72a) | `assimp: fix include directory with split outputs`                               |
| [`356869f2`](https://github.com/NixOS/nixpkgs/commit/356869f27dcabb116c2f07eb8965cc0727eb8b6e) | `tailscale: 1.20.1 -> 1.20.2`                                                    |
| [`ce357018`](https://github.com/NixOS/nixpkgs/commit/ce3570183f0215cac413ee1bfda2f2de12715805) | `python3Packages.ipwhl: init at 1.0.0`                                           |
| [`c9547469`](https://github.com/NixOS/nixpkgs/commit/c9547469eb6600fb0db831a0e4f51b07192e5da5) | `steampipe: 0.11.2 -> 0.12.0`                                                    |
| [`6ac41546`](https://github.com/NixOS/nixpkgs/commit/6ac415468d30671e31fb3f1c8a95717018f32096) | `sentry-cli: 1.71.0 -> 1.72.0`                                                   |
| [`36193587`](https://github.com/NixOS/nixpkgs/commit/361935877a1f63396403c0cac7d837db0938d5c0) | `traefik: 2.5.6 -> 2.5.7`                                                        |
| [`6e7fc6fb`](https://github.com/NixOS/nixpkgs/commit/6e7fc6fb5071ebd6310c71ee18079ac45bdb2236) | `tuptime: pass through nixosTests.tuptime`                                       |
| [`a3d9b17b`](https://github.com/NixOS/nixpkgs/commit/a3d9b17b5d17f4f59d1a4ce530127e80093d504e) | `umockdev: 0.17.5 -> 0.17.6`                                                     |
| [`007af342`](https://github.com/NixOS/nixpkgs/commit/007af34263d102667f077363b3958e6bf4b05ea8) | `google-chrome: add /run/opengl-driver/share/vulkan/icd.d/ to path`              |
| [`ed49a253`](https://github.com/NixOS/nixpkgs/commit/ed49a25322877f16885c4bbed5333563b4dce1db) | `tuptime: 5.0.2 -> 5.1.0`                                                        |
| [`93768bf8`](https://github.com/NixOS/nixpkgs/commit/93768bf840da0b43fc8cdafcf0cf0d4098b0a2e4) | `internetarchive: 2.2.0 -> 2.3.0`                                                |
| [`b93e9e49`](https://github.com/NixOS/nixpkgs/commit/b93e9e495ea262479e8493baa4002019e44e7abb) | `firecracker: 0.24.5 -> 0.25.2`                                                  |
| [`c357e0d8`](https://github.com/NixOS/nixpkgs/commit/c357e0d8cb277ff3ec06a48ad2fbe6e62da07b15) | `vultr-cli: 2.11.3 -> 2.12.0`                                                    |
| [`ac06871a`](https://github.com/NixOS/nixpkgs/commit/ac06871a54b9200b2f599502fa607b8da0dbe81e) | `pantheon.elementary-calendar: 6.0.3 -> 6.1.0`                                   |
| [`7fcddf2b`](https://github.com/NixOS/nixpkgs/commit/7fcddf2b22d19a9f9ac339c1b190e9ec6f4a6883) | `catcli: 0.7.4 -> 0.8.0`                                                         |
| [`a574ff99`](https://github.com/NixOS/nixpkgs/commit/a574ff9929f906208cd42827c7d3a0256bd18705) | `webkitgtk: 2.34.3 -> 2.34.4`                                                    |
| [`32368f32`](https://github.com/NixOS/nixpkgs/commit/32368f32d1644257e961fd0c2b8271b045970e06) | `nixos/redis: fix port option`                                                   |
| [`7965b464`](https://github.com/NixOS/nixpkgs/commit/7965b464ed1bafde3be96c771f78295c3a0ee68e) | `python3Packages.ibis-framework: use pytestCheckHook`                            |
| [`5c7f80c4`](https://github.com/NixOS/nixpkgs/commit/5c7f80c45425ad3b7b3b9737bdad476ed16d5173) | `python3Packages.ibis-framework: share the version variable`                     |
| [`01665b3d`](https://github.com/NixOS/nixpkgs/commit/01665b3dd555f8e16dba7705f32f098d1bb58ce0) | `python3Packages.ibis-framework: use a specific rev for testing-data`            |
| [`9f073cf8`](https://github.com/NixOS/nixpkgs/commit/9f073cf8d6ca16ed66ca0e3e12f17f6e1b3a8156) | `python3Packages.ibis-framework: 1.3.0 -> 2.1.1`                                 |
| [`10bc0b32`](https://github.com/NixOS/nixpkgs/commit/10bc0b32d8cb72b7f56689c6f102a27975dd24b7) | `chromiumBeta: 98.0.4758.54 -> 98.0.4758.66`                                     |
| [`9cabde84`](https://github.com/NixOS/nixpkgs/commit/9cabde84bed4ca01fc56bf499e9c875ad6e2b343) | `tree-sitter: add org grammar to update.nix`                                     |
| [`29644ea7`](https://github.com/NixOS/nixpkgs/commit/29644ea70b9aa60d2fc0a0cd023111b801623ffc) | `python3Packages.pywayland: 0.4.8 -> 0.4.9`                                      |
| [`bf647eb8`](https://github.com/NixOS/nixpkgs/commit/bf647eb89d966a24c3930ddfe74e1f63d4cb4fc1) | `bukut: fix incorrect sha256 hash`                                               |
| [`c1d1cdfe`](https://github.com/NixOS/nixpkgs/commit/c1d1cdfe13df3f0923d7b751981570808b07601f) | `pdfstudio: refactor / use jdk11`                                                |
| [`78c338cb`](https://github.com/NixOS/nixpkgs/commit/78c338cb10067c45d370709b4f9ec75bdd075328) | `npush: init at 0.7`                                                             |
| [`7d636aba`](https://github.com/NixOS/nixpkgs/commit/7d636aba15c342bafcdb73130ed605e6ee5ae149) | `rgp: 1.11 -> 1.12`                                                              |
| [`7e6916dc`](https://github.com/NixOS/nixpkgs/commit/7e6916dc3e6bc9b8aac67e997fd21882a634cf11) | `keycard-cli: mark as broken on darwin`                                          |
| [`4f16a1b3`](https://github.com/NixOS/nixpkgs/commit/4f16a1b33465766175b1da2c386cec5b2ddfaf7a) | `dnstwist: 20211204 -> 20220120`                                                 |
| [`64560de4`](https://github.com/NixOS/nixpkgs/commit/64560de406ec701e26f286163a8d775ed2d0f8b6) | `nixos/networkd: fix networking.networkd.static test`                            |
| [`e01fa67c`](https://github.com/NixOS/nixpkgs/commit/e01fa67cdd9a976dc9b123e82f451f53b4dfe527) | `drawing: 0.8.3 -> 0.8.5`                                                        |
| [`88ef0666`](https://github.com/NixOS/nixpkgs/commit/88ef0666443aea0f9088a18056f923240fd1424f) | `noto-fonts-cjk: fix rendering issues`                                           |
| [`19c7496c`](https://github.com/NixOS/nixpkgs/commit/19c7496cc8ea24bb3240208c503c9c0dc6207965) | `python39Packages.dogpile-cache: 1.1.4 -> 1.1.5`                                 |
| [`36b052a6`](https://github.com/NixOS/nixpkgs/commit/36b052a6d5c3a0bff187105599de70c26702c83d) | `yt-dlp: 2021.12.27 -> 2022.1.21`                                                |
| [`ad7fa3b5`](https://github.com/NixOS/nixpkgs/commit/ad7fa3b56fb5961e2d89107545df6ad5f4f65dc8) | `python39Packages.green: 3.4.0 -> 3.4.1`                                         |
| [`cf6178cc`](https://github.com/NixOS/nixpkgs/commit/cf6178cccbfbfd06177a2b3bdb50e9c019d255bf) | `python39Packages.django-anymail: 8.4 -> 8.5`                                    |
| [`7e1ed184`](https://github.com/NixOS/nixpkgs/commit/7e1ed18419f18e4732acf1cc6b4cde2cd27bb529) | `bukut: init at 0.11`                                                            |
| [`4ddb05e5`](https://github.com/NixOS/nixpkgs/commit/4ddb05e51a84dbe32e2088bbeb85543b02740320) | `vcluster: init at 0.5.3`                                                        |
| [`1c33846a`](https://github.com/NixOS/nixpkgs/commit/1c33846ae97ee27c57a977641bf3a7c961335c82) | `antennas: unstable-2021-01-21 -> 4.1.0`                                         |
| [`f888e66a`](https://github.com/NixOS/nixpkgs/commit/f888e66ad495c6772eada50a85fbe735dbbf8fd4) | `cwltool: 3.1.20211107152837 -> 3.1.20220119140128`                              |
| [`b6718ec0`](https://github.com/NixOS/nixpkgs/commit/b6718ec0aa5e09ec294cc073b3c3c20c3353d58c) | `pluginupdate.py: fix regression with plugin line splitting`                     |
| [`a247ac22`](https://github.com/NixOS/nixpkgs/commit/a247ac22526ff2122c6e7b120d36bb7d4be38109) | `signal-cli: 0.10.0 -> 0.10.1`                                                   |
| [`08dac75a`](https://github.com/NixOS/nixpkgs/commit/08dac75a3607f5b9b5112b8f5654ec9f467d720d) | `gnupg-pkcs11-scd: 0.9.2 -> 0.10.0`                                              |
| [`171c9517`](https://github.com/NixOS/nixpkgs/commit/171c95176b104ead4d23211029bc981f8ec986d7) | `mycli: 1.24.2 -> 1.24.3`                                                        |
| [`f9aa54c8`](https://github.com/NixOS/nixpkgs/commit/f9aa54c83ef27c7e824ba406bc177d60dc69b5f4) | `evolution: 3.42.2 -> 3.42.3`                                                    |
| [`90ec465b`](https://github.com/NixOS/nixpkgs/commit/90ec465b1650e4f3e417b7ffc5b35b19afb258a6) | `gnome.nautilus: 41.1 -> 41.2`                                                   |
| [`41ccfc6e`](https://github.com/NixOS/nixpkgs/commit/41ccfc6e687bf5dd85a51936f9daa7d1f0aeecc5) | `meld: 3.21.0 -> 3.21.1`                                                         |
| [`c71e1d7e`](https://github.com/NixOS/nixpkgs/commit/c71e1d7e74eb3776d66ea3b0a267135b0265f029) | `jrsonnet: mark as broken on darwin`                                             |
| [`0a3e3ca1`](https://github.com/NixOS/nixpkgs/commit/0a3e3ca1f8f381ec108dfa7182b44e2fdd069fca) | `python310Packages.jsmin: 2.2.2 -> 3.0.1`                                        |
| [`bec8881e`](https://github.com/NixOS/nixpkgs/commit/bec8881e529a4be8efbe1e74b50e8b4dd56ccc63) | `bash_unit: 1.8.0 -> 1.9.1`                                                      |
| [`7d67bb49`](https://github.com/NixOS/nixpkgs/commit/7d67bb493563620c7f87f6c50c0f172120bd3f1c) | `terraform-providers.teleport: remove (#155959)`                                 |
| [`8b79938c`](https://github.com/NixOS/nixpkgs/commit/8b79938ccb2b5cc768690cdc3d78821985facf20) | `packer: 1.7.8 -> 1.7.9 (#156040)`                                               |
| [`787ced64`](https://github.com/NixOS/nixpkgs/commit/787ced6423cbfd130471aaf0a5e66ca3fd3e6af0) | `helmfile: 0.142.0 -> 0.143.0`                                                   |
| [`cfe5cf10`](https://github.com/NixOS/nixpkgs/commit/cfe5cf106c499ba2a9154a086fc217ce5902a4db) | `headsetcontrol: init at 2.6`                                                    |
| [`df6976b6`](https://github.com/NixOS/nixpkgs/commit/df6976b6cf12b263b986addd5b1600950cffeb52) | `maintainers: add leixb`                                                         |
| [`6578becc`](https://github.com/NixOS/nixpkgs/commit/6578beccdb9cb060920739140bc861f567609e9a) | `supercollider: 3.12.1 -> 3.12.2`                                                |
| [`4ac44311`](https://github.com/NixOS/nixpkgs/commit/4ac443115628093d8077073c07664cf33fa2f5eb) | `rmview: 3.0 -> 3.1 (#155992)`                                                   |
| [`20d81aaf`](https://github.com/NixOS/nixpkgs/commit/20d81aaf78636171aeee4032308a95ccecb1ab63) | `lagrange: 1.10.0 -> 1.10.1`                                                     |
| [`b1a80228`](https://github.com/NixOS/nixpkgs/commit/b1a80228a69d8b9add9c2ccf8c045f667df2f784) | `grafana: 8.3.3 -> 8.3.4`                                                        |
| [`34bff987`](https://github.com/NixOS/nixpkgs/commit/34bff987ae5f7181d0cbc141e759ded66f2b8639) | `kodiPackages.dateutil: 2.8.1+matrix.1 -> 2.8.2`                                 |
| [`c365aeff`](https://github.com/NixOS/nixpkgs/commit/c365aeff51e29667a63a2215aa58daf8966b83e0) | `jackett: 0.20.285 -> 0.20.417`                                                  |
| [`1394bfc3`](https://github.com/NixOS/nixpkgs/commit/1394bfc32a7f2398815b000ad11812f2da7ea2d5) | `types.singleLineStr: Improve description`                                       |
| [`f4838065`](https://github.com/NixOS/nixpkgs/commit/f48380650108326b9740ec2db75caf49eec9cf17) | `i3status-rust: 0.20.7 -> 0.21.2`                                                |
| [`47b49d4c`](https://github.com/NixOS/nixpkgs/commit/47b49d4c9bcb93e08acec0fd625996a557147f76) | `git-cola: 3.11.0 -> 3.12.0`                                                     |
| [`b52131c2`](https://github.com/NixOS/nixpkgs/commit/b52131c2d17bc28dc828ba33454fcd1e9d0ef744) | `flexget: 3.2.8 -> 3.2.11`                                                       |
| [`51252591`](https://github.com/NixOS/nixpkgs/commit/51252591303a0006d6c91f01c48ca64104a152be) | `firefox-unwrapped: 96.0.1 -> 96.0.2`                                            |
| [`ba7e2e7b`](https://github.com/NixOS/nixpkgs/commit/ba7e2e7b35a89925a0ef08e9e3e07d3cda3f02d6) | `dconf2nix: 0.0.10 -> 0.0.11`                                                    |
| [`78668ffc`](https://github.com/NixOS/nixpkgs/commit/78668ffca468cc1dca6fe7102fb4aa8ff8891947) | `cudatext: 1.153.0 -> 1.155.0`                                                   |
| [`d32ae950`](https://github.com/NixOS/nixpkgs/commit/d32ae950ee28d585c967e3ae27d086443fc627c3) | `calibre-web: 0.6.14 -> 0.6.15`                                                  |
| [`bac86dac`](https://github.com/NixOS/nixpkgs/commit/bac86dacdfe04819f658fe02ed388c3db48c21b9) | `gost: init at 2.11.1`                                                           |
| [`115521db`](https://github.com/NixOS/nixpkgs/commit/115521dbdcf018716873b56fb10a6fc33838bec5) | `v2ray-geoip: 202201130034 -> 202201200035`                                      |
| [`9c714e6f`](https://github.com/NixOS/nixpkgs/commit/9c714e6f8e10b32bc9503facc4dee1cc996c8368) | `qgnomeplatform: 0.8.3 -> 0.8.4`                                                 |
| [`ab67b82d`](https://github.com/NixOS/nixpkgs/commit/ab67b82d7b2d38af0ae171b4b401cb56b41c6bb7) | `waypipe: fix cross compilation, set strictDeps`                                 |
| [`3e2f9653`](https://github.com/NixOS/nixpkgs/commit/3e2f9653024b035745d3c4215268e00bf8eeb8ed) | `scli: 0.6.5 -> 0.6.6`                                                           |
| [`c9ed85a9`](https://github.com/NixOS/nixpkgs/commit/c9ed85a957fece9ab167c08a32524966c4995653) | `python310Packages.youtube-search-python: 1.5.3 -> 1.6.0`                        |
| [`09031c22`](https://github.com/NixOS/nixpkgs/commit/09031c22ca86e3b2ffdb2aaf36ecfa9c9fb3cbc9) | `liberasurecode: generate man pages`                                             |
| [`442790a3`](https://github.com/NixOS/nixpkgs/commit/442790a3136627eab7204f17d563ec06c5c114a8) | `python310Packages.wsgi-intercept: 1.9.2 -> 1.9.3`                               |
| [`32623fcc`](https://github.com/NixOS/nixpkgs/commit/32623fcca0a1f08aa0a6f0b867fd0bcc2c69f0f3) | `tetrio-desktop: init at 8.0.0`                                                  |
| [`e3391057`](https://github.com/NixOS/nixpkgs/commit/e33910576f087365075faab293b9dd84ad436fbe) | `gay: init at 1.2.8`                                                             |
| [`64eac0ea`](https://github.com/NixOS/nixpkgs/commit/64eac0ea11db33f062cebb680f5b6c1270c96de4) | `geeqie: 1.6 -> 1.7.1`                                                           |
| [`fc8ddca8`](https://github.com/NixOS/nixpkgs/commit/fc8ddca83b9fb7b0375f7c176b5734a0f747939b) | `ungoogled-chromium: 97.0.4692.71 -> 97.0.4692.99`                               |
| [`1147d724`](https://github.com/NixOS/nixpkgs/commit/1147d724813cb9dbb8cd8728cf7ad195fa2155ca) | ``nixos: use `uniq` in the type of system.build``                                |
| [`a1c5e5bc`](https://github.com/NixOS/nixpkgs/commit/a1c5e5bc40749652503cd956e777455e2180b663) | `chromium: 97.0.4692.71 -> 97.0.4692.99`                                         |
| [`eda8da32`](https://github.com/NixOS/nixpkgs/commit/eda8da3286e270a345560f8bf1b0b06a3e4664e7) | `thermald: 2.4.7 -> 2.4.8`                                                       |
| [`97264ace`](https://github.com/NixOS/nixpkgs/commit/97264aced22d6ee576d26ea1f759af69b33f7b62) | `python310Packages.fastavro: 1.4.4 -> 1.4.9 (#155712)`                           |
| [`b1f70216`](https://github.com/NixOS/nixpkgs/commit/b1f70216575e22b001ccf109e81129ad2cfff45b) | ``nixos/container-config: Only use `true` as fallback``                          |
| [`02c86b79`](https://github.com/NixOS/nixpkgs/commit/02c86b798cbea74f7f38bec0c26987d5cd25a246) | `terraform-providers.vpsadmin: 0.1.0 -> 0.2.0`                                   |
| [`1193b6da`](https://github.com/NixOS/nixpkgs/commit/1193b6dae6d0b86be87796b104d54b4bd6c5787a) | `vimPlugins: update`                                                             |
| [`4f0cb8a0`](https://github.com/NixOS/nixpkgs/commit/4f0cb8a0715949a84d74a77ed41483a66aacd2bb) | `update.py: mention GITHUB_API_TOKEN in the help`                                |
| [`a5e98cca`](https://github.com/NixOS/nixpkgs/commit/a5e98cca746a7f4d2a3af2c83838354261908f02) | `vimPlugins.lsp_lines-nvim: init at 2022-01-10`                                  |
| [`46c68ad4`](https://github.com/NixOS/nixpkgs/commit/46c68ad4188f2954d8a98c1f4ebdeea747985976) | `update.py: support remotes other than github`                                   |
| [`507bc251`](https://github.com/NixOS/nixpkgs/commit/507bc2510047944f4262c622d0d4712cff46018f) | `cargo-bloat: 0.10.1 -> 0.11.0`                                                  |
| [`5eb6c091`](https://github.com/NixOS/nixpkgs/commit/5eb6c091781fe2b14ae7cc5d57520c061d6189a0) | `python3Packages.msoffcrypto-tool: 4.12.0 -> 5.0.0`                              |
| [`e83bbd6f`](https://github.com/NixOS/nixpkgs/commit/e83bbd6f0491cf1c9a36c9ff6c8122c32e157c49) | `python3Packages.mailchecker: 4.1.8 -> 4.1.9`                                    |
| [`2cbde6d1`](https://github.com/NixOS/nixpkgs/commit/2cbde6d1a19eaae24271ac2af32e70371b801534) | `udpt: 3.1.0 -> 3.1.1`                                                           |
| [`8e517fc7`](https://github.com/NixOS/nixpkgs/commit/8e517fc7eabdd78d950db8504991bc7ad5dbda64) | `pass2csv: 0.3.1 -> 0.3.2`                                                       |
| [`9c982ef9`](https://github.com/NixOS/nixpkgs/commit/9c982ef93e620c4f06813716d11e6f696be399b9) | `deno: 1.17.3 -> 1.18.0`                                                         |
| [`52d78ef6`](https://github.com/NixOS/nixpkgs/commit/52d78ef6db9bbd6dd840cd1b67d28759728c1c56) | `pdfarranger: 1.8.1 -> 1.8.2`                                                    |
| [`c0dd5860`](https://github.com/NixOS/nixpkgs/commit/c0dd5860ea02da6db98a613b2737441f1be4caa5) | `python310Packages.wled: 0.10.2 -> 0.11.0`                                       |
| [`b1724b2f`](https://github.com/NixOS/nixpkgs/commit/b1724b2f81b0bb43036d05acca344390ffd9092d) | `nixos/activation-script: ensure gcroots dir exists`                             |
| [`a5beb54c`](https://github.com/NixOS/nixpkgs/commit/a5beb54cf076a563879274cb0b9bcd2668316658) | `nushell: 0.42.0 -> 0.43.0`                                                      |
| [`4326ef50`](https://github.com/NixOS/nixpkgs/commit/4326ef50cfee1d36b026e9f79744466080494eab) | `python3Packages.mutmut: init at 2.2.0`                                          |
| [`89cc4c1e`](https://github.com/NixOS/nixpkgs/commit/89cc4c1ee66927cf1a4ed84184884be672450e38) | `linux: 5.4.172 -> 5.4.173`                                                      |
| [`581019ba`](https://github.com/NixOS/nixpkgs/commit/581019ba48517712475acf1472fccd07a92901e3) | `linux: 5.16.1 -> 5.16.2`                                                        |
| [`fea530a5`](https://github.com/NixOS/nixpkgs/commit/fea530a537feff39102262fa7612914834495f5f) | `linux: 5.15.15 -> 5.15.16`                                                      |
| [`6c1f8548`](https://github.com/NixOS/nixpkgs/commit/6c1f8548a278f3b8ae0c8a8f8d3089bcf3e696fa) | `linux: 5.10.92 -> 5.10.93`                                                      |
| [`ca58bd0a`](https://github.com/NixOS/nixpkgs/commit/ca58bd0a50f38de43b401df716806c0f83479a8e) | `nixos/networkd: Add routes from interfaces to [Route] section of .network file` |
| [`6565458f`](https://github.com/NixOS/nixpkgs/commit/6565458f9db0dfaffb8515b4397c7682891e7308) | `nixos/borgbackup: remove literalDocBook in description`                         |
| [`6bbd1925`](https://github.com/NixOS/nixpkgs/commit/6bbd192555679f4ea70cf1e340c5fdb798eaa515) | `s3ql: 3.8.0 -> 3.8.1`                                                           |
| [`d6229c2d`](https://github.com/NixOS/nixpkgs/commit/d6229c2d86fa95bda24730d5ef666e966ac3c2d1) | `google-cloud-logging: fix pythonImportsCheck typo`                              |
| [`7467473c`](https://github.com/NixOS/nixpkgs/commit/7467473c5f422f42eb9172bf5f82d416b652dd30) | `vscode-extensions.haskell.haskell: 1.7.1 -> 1.8.0`                              |
| [`44d01676`](https://github.com/NixOS/nixpkgs/commit/44d01676382a72705636e97c3c3a5d3da3070009) | `gitlab-runner: 14.6.0 -> 14.7.0 (#155813)`                                      |
| [`6b7e9eda`](https://github.com/NixOS/nixpkgs/commit/6b7e9edac55ab04bb7151b85cbc3210ef9969b39) | `vscode-extensions.hashicorp.terraform: 2.18.0 -> 2.19.0`                        |
| [`2d53e621`](https://github.com/NixOS/nixpkgs/commit/2d53e621110df164456003475369e010c38dd0f9) | `compactor: 1.1.0 -> 1.2.0`                                                      |
| [`7d9d09e1`](https://github.com/NixOS/nixpkgs/commit/7d9d09e1f7e6cf4e879cfb1457a26bb91fd3fb8d) | `avra: 1.3.0 -> 1.4.2`                                                           |