### PR TITLE
chore(flake/utils): `74f7e431` -> `846b2ae0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -45,11 +45,11 @@
     },
     "utils": {
       "locked": {
-        "lastModified": 1638122382,
-        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "lastModified": 1642700792,
+        "narHash": "sha256-XqHrk7hFb+zBvRg6Ghl+AZDq03ov6OshJLiSWOoX5es=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "rev": "846b2ae0fc4cc943637d3d1def4454213e203cba",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                               | Commit Message                         |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`846b2ae0`](https://github.com/numtide/flake-utils/commit/846b2ae0fc4cc943637d3d1def4454213e203cba) | `Update default.nix (#42)`             |
| [`3f197dc7`](https://github.com/numtide/flake-utils/commit/3f197dc7591cc6edc83e1eb44698283c19fd28a2) | `add system map for convenience (#55)` |