### PR TITLE
chore(flake/nixpkgs): `cb19ae8a` -> `e1b353e8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1642866692,
-        "narHash": "sha256-plKaYrIfvZ27ZdfPIWG2v2tchZFtsRL4gNcst7DTBCs=",
+        "lastModified": 1643428210,
+        "narHash": "sha256-ympCeHuXeGitpnegE0raAtWLNg3vZbjj5QbbMvvBGCQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cb19ae8afe362b6c686ba271cd41c7b008071456",
+        "rev": "e1b353e890801a759efe9a4c42f6984e47721f0d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                      |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
| [`019bc5f7`](https://github.com/NixOS/nixpkgs/commit/019bc5f7a1d503b29e72f72443884ff52e90d7e5) | `v2ray-geoip: 202201200035 -> 202201270031`                                                         |
| [`3bd2f239`](https://github.com/NixOS/nixpkgs/commit/3bd2f2390d91916186506c1f5ac156523a89464d) | `maintainers: update github handle for Gordias`                                                     |
| [`360829c7`](https://github.com/NixOS/nixpkgs/commit/360829c7499387d9e311b7f7d9bfe59fae11d290) | `yadm: use resholvePackage (#154190)`                                                               |
| [`41f927b4`](https://github.com/NixOS/nixpkgs/commit/41f927b43358234e2368a745ad5d8e852389dc63) | `verilator: 4.210 -> 4.218 (#157122)`                                                               |
| [`60c571be`](https://github.com/NixOS/nixpkgs/commit/60c571bef642a84bd10b5c42395e3de020d35327) | `xh: 0.14.1 -> 0.15.0`                                                                              |
| [`269b5157`](https://github.com/NixOS/nixpkgs/commit/269b51570319d9f779fc74a12ff855b17768aca9) | `nixVersions: makeExtensible`                                                                       |
| [`0e42bc10`](https://github.com/NixOS/nixpkgs/commit/0e42bc10c8eecfeb5e61ffe29a1236628c136da5) | `nixVersions: use recurseIntoAttrs`                                                                 |
| [`46d4c9e6`](https://github.com/NixOS/nixpkgs/commit/46d4c9e6a4a1bc37fb22d46dbbcc4bdaf8c30fae) | `prometheus-postgres-exporter: 0.10.0 -> 0.10.1`                                                    |
| [`1e8d75b0`](https://github.com/NixOS/nixpkgs/commit/1e8d75b093ee7c759b171f4f7b202f9a7de455ff) | `live555: add vlc test`                                                                             |
| [`e87db3c8`](https://github.com/NixOS/nixpkgs/commit/e87db3c8c332cfed455f39a7784f473bab886c2d) | `poke: 1.4 -> 2.0 (#157108)`                                                                        |
| [`fe580dcf`](https://github.com/NixOS/nixpkgs/commit/fe580dcffa4a82da576cc61f27c9996b8bda115e) | `terraform: fix the plugins wrapper`                                                                |
| [`1e31734c`](https://github.com/NixOS/nixpkgs/commit/1e31734c9e0e82120b06636d8db8921a314f9e32) | `drawio: 16.4.0 -> 16.5.1`                                                                          |
| [`957b835e`](https://github.com/NixOS/nixpkgs/commit/957b835e7153e75de66e1b0ffeedc894d6a39c63) | `python310Packages.pytest-httpserver: 1.0.3 -> 1.0.4`                                               |
| [`a26134ff`](https://github.com/NixOS/nixpkgs/commit/a26134ffd45ae5eca1faab88ca997d71da7c26ac) | `nixos/nix-daemon: Fix misspelled old option name`                                                  |
| [`84726d05`](https://github.com/NixOS/nixpkgs/commit/84726d052e8512cd7697c6cac3c25d044b116af1) | `libunibreak: 4.3 -> 5.0`                                                                           |
| [`cdcb8468`](https://github.com/NixOS/nixpkgs/commit/cdcb8468e67a0bad93f4fbf76179d5dccce67401) | `libwpe-fdo: 1.10.0 -> 1.12.0`                                                                      |
| [`b612b6bd`](https://github.com/NixOS/nixpkgs/commit/b612b6bd37202cab045ba2fc3dc458e2f17e2e8b) | `libredwg: 0.12 -> 0.12.4`                                                                          |
| [`078e4df0`](https://github.com/NixOS/nixpkgs/commit/078e4df095d9d1f4b5c4cb30da88546f20473b3a) | `gupnp: 1.4.1 -> 1.4.3`                                                                             |
| [`65a33fec`](https://github.com/NixOS/nixpkgs/commit/65a33fec2a6ab71d165e2caacc7254c6669edec0) | `python3Packages.jaxlibWithCuda: init at 0.1.75 (#157055)`                                          |
| [`5b958f0c`](https://github.com/NixOS/nixpkgs/commit/5b958f0c226edd2a90d1f776cd7db0fdf47276e3) | `python3Packages.apache-beam: fix build`                                                            |
| [`da815397`](https://github.com/NixOS/nixpkgs/commit/da815397a7e60c89bff5a80b24a7ca713599078e) | `python3Packages.sentry-sdk: disable web test`                                                      |
| [`ec0a4972`](https://github.com/NixOS/nixpkgs/commit/ec0a4972c81a18b02d6a7b9c49b491d8f9ddcd1d) | `vimPlugins.fidget-nvim: init at 2022-01-26`                                                        |
| [`232fc419`](https://github.com/NixOS/nixpkgs/commit/232fc41914cdd64bda2cf8df021c23b20ccf363e) | `vimPlugins: update`                                                                                |
| [`68544ccc`](https://github.com/NixOS/nixpkgs/commit/68544ccc3460d7ebecfb921f1841d7fece2319c9) | `python310Packages.nengo: 3.1.0 -> 3.2.0`                                                           |
| [`b404fb82`](https://github.com/NixOS/nixpkgs/commit/b404fb822899a3c2ff83d0d691debcfaaa564303) | `python39Packages.pdm-pep517: 0.9.4 -> 0.10.2`                                                      |
| [`9441234a`](https://github.com/NixOS/nixpkgs/commit/9441234abcec11c95d60cf1900fc63c3600c7320) | `rpm-ostree: 2021.14 -> 2022.1`                                                                     |
| [`bd8eca52`](https://github.com/NixOS/nixpkgs/commit/bd8eca52fadda92f9ac987b386388469f5b47071) | `timetagger: use SPDX 3.0 license identifier`                                                       |
| [`d90ae4bf`](https://github.com/NixOS/nixpkgs/commit/d90ae4bfac0f23a38700de4278486c9483015504) | `python3Packages.timetagger: disable tests on python versions older than 3.10`                      |
| [`ef0bee50`](https://github.com/NixOS/nixpkgs/commit/ef0bee504770e9d1b8ee553425c379556bccf60e) | `python3Packages.timetagger: format`                                                                |
| [`60376d0d`](https://github.com/NixOS/nixpkgs/commit/60376d0d7dca6ed29d60280cd17b27b37645d141) | `timetagger: 22.1.2 -> 22.1.3`                                                                      |
| [`581b57b2`](https://github.com/NixOS/nixpkgs/commit/581b57b274cab94bc89d060df17d0a5509d68b65) | `netpbm: 10.96.2 -> 10.97.2`                                                                        |
| [`f07cd03e`](https://github.com/NixOS/nixpkgs/commit/f07cd03eadba172e2c7c287144a36f8451d3d389) | `python3Packages.importlab: init at 0.7`                                                            |
| [`c707c3ab`](https://github.com/NixOS/nixpkgs/commit/c707c3ab3e568503090a61cc6c04865fb4876b3e) | `python3Packages.meshtastic: 1.2.76 -> 1.2.77`                                                      |
| [`0b2eb3e2`](https://github.com/NixOS/nixpkgs/commit/0b2eb3e2a6635d11088b081c6c1ff9b2b416bc84) | `vips: 8.12.1 -> 8.12.2`                                                                            |
| [`13c3d9f5`](https://github.com/NixOS/nixpkgs/commit/13c3d9f5c8c3efb12417dc250061597a92e5d530) | `python310Packages.trimesh: 3.9.42 -> 3.9.43`                                                       |
| [`614a3c32`](https://github.com/NixOS/nixpkgs/commit/614a3c32292885f23a9771b10dc0711ffff489e2) | `python310Packages.pony: 0.7.15rc1 -> 0.7.16`                                                       |
| [`71557df5`](https://github.com/NixOS/nixpkgs/commit/71557df5928b0e90e4238b9b81f0145df00b8cd6) | `telepresence2: 2.4.9 -> 2.4.10`                                                                    |
| [`fb6b8ffb`](https://github.com/NixOS/nixpkgs/commit/fb6b8ffbca4f14784853f82e2ae216aa0efe0547) | `python310Packages.jdatetime: 3.8.1 -> 3.8.2`                                                       |
| [`50b04db0`](https://github.com/NixOS/nixpkgs/commit/50b04db0c0d2822a046945951cf93ed1f83f7501) | `python310Packages.aioconsole: 0.3.3 -> 0.4.0`                                                      |
| [`6db3ef22`](https://github.com/NixOS/nixpkgs/commit/6db3ef222870aaae2a6a8aebebd9f1c60b72453d) | `python310Packages.pymazda: 0.3.1 -> 0.3.2`                                                         |
| [`066a7a30`](https://github.com/NixOS/nixpkgs/commit/066a7a3091b307ed1d47f79191fc0be18611e107) | `python310Packages.chiavdf: 1.0.4 -> 1.0.5`                                                         |
| [`5911f67c`](https://github.com/NixOS/nixpkgs/commit/5911f67c522127961b4de46791e639ca9aa8e62d) | `python310Packages.svglib: 1.2.0 -> 1.2.1`                                                          |
| [`0646cd48`](https://github.com/NixOS/nixpkgs/commit/0646cd48211abc34f1fe6b95a7be3d89dcc4a4b7) | `python310Packages.types-decorator: 5.1.3 -> 5.1.4`                                                 |
| [`da637a36`](https://github.com/NixOS/nixpkgs/commit/da637a36249f283b2d785831814165559a1e966c) | `python310Packages.httpagentparser: 1.9.1 -> 1.9.2`                                                 |
| [`80ec92d5`](https://github.com/NixOS/nixpkgs/commit/80ec92d55a0ef54eeee13759258ac6acbdfcf2eb) | `openrgb: add desktop icon`                                                                         |
| [`0700dde6`](https://github.com/NixOS/nixpkgs/commit/0700dde63b10aff31b96240d83a035a6f0e7fd5e) | `php74Extensions.blackfire: 1.71.0 -> 1.72.0`                                                       |
| [`cc44eb98`](https://github.com/NixOS/nixpkgs/commit/cc44eb980615068d90f0affcbca1c1fb06c4451e) | `link-grammar: 5.9.1 -> 5.10.2`                                                                     |
| [`d4ecaf69`](https://github.com/NixOS/nixpkgs/commit/d4ecaf699e25872a010438c88ec24696cb727862) | `glib: correct update script`                                                                       |
| [`70574630`](https://github.com/NixOS/nixpkgs/commit/70574630cac16a0f657f3bdde59bf03d84fc231f) | `laminar: 1.1 -> 1.2`                                                                               |
| [`5efc8ca9`](https://github.com/NixOS/nixpkgs/commit/5efc8ca954272c4376ac929f4c5ffefcc20551d5) | `h: 1.0.0 -> 1.0.3 (#156966)`                                                                       |
| [`3f81985d`](https://github.com/NixOS/nixpkgs/commit/3f81985d746fbbfff71d91b6e34d70e9699de3c7) | `bcachefs-tools: 2021-12-25 -> 2022-01-12`                                                          |
| [`067201c3`](https://github.com/NixOS/nixpkgs/commit/067201c3cccc7e5290447a3d9a331c558179a75d) | `linux_testing-bcachefs: 2021-12-26 -> 2022-01-12`                                                  |
| [`07029944`](https://github.com/NixOS/nixpkgs/commit/07029944a55c5dee33ed0a2414605c61715487e9) | `river: make XWayland support optional (#157002)`                                                   |
| [`99deb1c4`](https://github.com/NixOS/nixpkgs/commit/99deb1c41814a9991756bae8793b074544743898) | `podman-compose: available on all unix platforms`                                                   |
| [`d6fba22f`](https://github.com/NixOS/nixpkgs/commit/d6fba22f2a3a2f81cc96f6723138d317c97d41e2) | `deno: 1.18.0 -> 1.18.1`                                                                            |
| [`63a65f2d`](https://github.com/NixOS/nixpkgs/commit/63a65f2d1acaff52ec38e027e67cf2f98a615273) | `macdylibbundler: 1.0.0 -> 1.0.4`                                                                   |
| [`36a038ca`](https://github.com/NixOS/nixpkgs/commit/36a038ca52fe70d44f22420316effd8db2e37100) | `python310Packages.pyweatherflowrest: 1.0.7 -> 1.0.8`                                               |
| [`36bea6f5`](https://github.com/NixOS/nixpkgs/commit/36bea6f5f8357ee4e06ab5f9e22c446e28a4b3af) | `darktable: set lua version in all-packages.nix`                                                    |
| [`a3690228`](https://github.com/NixOS/nixpkgs/commit/a36902286e17406c76996ee4525049d4d28ef543) | `yq-go: 4.17.2 -> 4.18.1`                                                                           |
| [`a9ebd6de`](https://github.com/NixOS/nixpkgs/commit/a9ebd6decfdb99b7b1445f0bb25ca721ec7ce616) | `dart: 2.14.3 -> 2.15.1`                                                                            |
| [`37df4305`](https://github.com/NixOS/nixpkgs/commit/37df4305c65ab6d3f34beebbacca491b4d122769) | `polymc: 1.0.4 -> 1.0.6`                                                                            |
| [`5253f848`](https://github.com/NixOS/nixpkgs/commit/5253f848dd03f490e4d0c1ce75f4cc841aed067b) | `python310Packages.types-futures: 3.3.7 -> 3.3.8`                                                   |
| [`86d7f2d5`](https://github.com/NixOS/nixpkgs/commit/86d7f2d5e1d1de07a18c524682057cc02caecdd5) | `linuxPackages.amdgpu-pro: fix build`                                                               |
| [`c053bd3a`](https://github.com/NixOS/nixpkgs/commit/c053bd3a4b7353a2f0bf3bd7c6b3949ecbf50748) | `bundler: 2.2.24 -> 2.3.6`                                                                          |
| [`8e660e42`](https://github.com/NixOS/nixpkgs/commit/8e660e42f60bd21580ca11cedaed4d3ed423118d) | `libesmtp: 1.0.6 -> 1.1.0`                                                                          |
| [`5bb20f9d`](https://github.com/NixOS/nixpkgs/commit/5bb20f9dc70e9ee16e21cc404b6508654931ce41) | `mandown: init at 0.1.3`                                                                            |
| [`8804d87b`](https://github.com/NixOS/nixpkgs/commit/8804d87bd35f52f81d964061457f14a39ee861c5) | `tailscale: 1.20.2 -> 1.20.3`                                                                       |
| [`c2d49ebb`](https://github.com/NixOS/nixpkgs/commit/c2d49ebbaa30b7f5175b09258dd9c6951d7a69ae) | `python310Packages.aioesphomeapi: 10.8.0 -> 10.8.1`                                                 |
| [`40057471`](https://github.com/NixOS/nixpkgs/commit/40057471f245e073a955020b4a1777d236b8fa9e) | `kdiff3: 1.8.5 -> 1.9.4`                                                                            |
| [`4b4f7e12`](https://github.com/NixOS/nixpkgs/commit/4b4f7e12cddb80dca862bd4a1d47ddfc9edb67ec) | `vault: 1.9.2 -> 1.9.3`                                                                             |
| [`16a14fbc`](https://github.com/NixOS/nixpkgs/commit/16a14fbc13425d087dd2d948ddc6df9e9c715489) | `thunderbird-unwrapped: 91.5.0 -> 91.5.1`                                                           |
| [`a175820f`](https://github.com/NixOS/nixpkgs/commit/a175820f63c00a7eb1b18c654aa5ad0f2b98c8b0) | `pokerth, pokerth-server: pin to boost16x to fix build`                                             |
| [`e684a831`](https://github.com/NixOS/nixpkgs/commit/e684a8310390b1a7ee1fd7bd163a874242c180d9) | `reaper: 6.43 -> 6.46`                                                                              |
| [`268157dc`](https://github.com/NixOS/nixpkgs/commit/268157dc83f8bbf421d983093715b6f667e976cf) | `nixos/nix-daemon: fix buildMachines eval`                                                          |
| [`b56e79f0`](https://github.com/NixOS/nixpkgs/commit/b56e79f0bdd5251386835ecb0ac05bede81a9d55) | `vorta: 0.8.2 -> 0.8.3`                                                                             |
| [`54cbee8d`](https://github.com/NixOS/nixpkgs/commit/54cbee8d9700668eaa51219f6c852b4019cfd2ba) | `root: tweak wrapping flags for auxiliary programs, avoid forcing CMAKE_CXX_STANDARD (#157069)`     |
| [`fef09da9`](https://github.com/NixOS/nixpkgs/commit/fef09da9973bad931741a6e0a48fe68535a840eb) | `lighttpd: add patch to fix build on darwin x86_64`                                                 |
| [`b0b0ffd4`](https://github.com/NixOS/nixpkgs/commit/b0b0ffd4662c75d2e94b7382901faa782d0e7acc) | `chromiumBeta: 98.0.4758.66 -> 98.0.4758.74`                                                        |
| [`d9e21f28`](https://github.com/NixOS/nixpkgs/commit/d9e21f284317f85b3476c0043f4efea87a226c3a) | `smooth: 0.9.8 -> 0.9.9`                                                                            |
| [`e533f9d3`](https://github.com/NixOS/nixpkgs/commit/e533f9d3b2f2c0d578c935741674d72a7a1ecee2) | `breitbandmessung: throw later for unsupported systems`                                             |
| [`37ca422c`](https://github.com/NixOS/nixpkgs/commit/37ca422c73e1c8f4276072bb36f2013be7aaae43) | `libosmium: 2.17.2 -> 2.17.3`                                                                       |
| [`725d843c`](https://github.com/NixOS/nixpkgs/commit/725d843cc80359ae475715e9815c6a3010fc0b7a) | `flatpak: 1.12.2 -> 1.12.4`                                                                         |
| [`de5bdb94`](https://github.com/NixOS/nixpkgs/commit/de5bdb94f355b03a34019c34905affc3310cf113) | `softether_4_25: drop`                                                                              |
| [`7a76b746`](https://github.com/NixOS/nixpkgs/commit/7a76b746d315a8209841beafb074b5c339dfe432) | `impressive: remove`                                                                                |
| [`68e9cd0f`](https://github.com/NixOS/nixpkgs/commit/68e9cd0f7eac10a8f82a3a8a5a46a0127eaa9b42) | `nixos/lib: Use SingleLineStr in systemd description`                                               |
| [`93f88be7`](https://github.com/NixOS/nixpkgs/commit/93f88be7d11bb7bf62bcd9b8767db41cb9d68b03) | `python3Packages.treex: jaxlib belongs in buildInputs`                                              |
| [`236bab3f`](https://github.com/NixOS/nixpkgs/commit/236bab3f1fbb85e06ee21c813253f192f31289c0) | `python3Packages.optax: jaxlib belongs in buildInputs`                                              |
| [`c674a64c`](https://github.com/NixOS/nixpkgs/commit/c674a64ce671d3b8df1b6afa57e581dc47d793cd) | `python3Packages.flax: jaxlib belongs in buildInputs`                                               |
| [`9d9a54ad`](https://github.com/NixOS/nixpkgs/commit/9d9a54adeaff2f1c4d46dad6baa8084867303b71) | `python3Packages.elegy: jaxlib belongs in buildInputs`                                              |
| [`97a90b8d`](https://github.com/NixOS/nixpkgs/commit/97a90b8d6fb51d3308255a90ba9c5f6a2b9e7a0e) | `python3Packages.treeo: jaxlib is a test dependency`                                                |
| [`501df061`](https://github.com/NixOS/nixpkgs/commit/501df061ed4be9c1609bbb0c73cddf458dfc3f80) | `python3Packages.jmp: jaxlib is a test dependency`                                                  |
| [`6c2acb04`](https://github.com/NixOS/nixpkgs/commit/6c2acb04c244f6065f223072cd6b1829114560b7) | `python3Packages.dm-haiku: jaxlib is a test dependency`                                             |
| [`617d557d`](https://github.com/NixOS/nixpkgs/commit/617d557d3bdd0d558d52ed423314ac12ead6e8e3) | `gnome-2048: init at 3.38.2`                                                                        |
| [`1387fd0f`](https://github.com/NixOS/nixpkgs/commit/1387fd0fd14d2ba0c948cd4f27e2a9366bffba3c) | `keepalived: 2.2.4 -> 2.2.7`                                                                        |
| [`f8c8a891`](https://github.com/NixOS/nixpkgs/commit/f8c8a8918af3c840c0eaba6fe652016a1ced85e0) | `flatpak-builder: 1.2.0 -> 1.2.2`                                                                   |
| [`8909cf13`](https://github.com/NixOS/nixpkgs/commit/8909cf13be969d216acf0ddc5efa7ae87865975b) | `python310Packages.azure-mgmt-applicationinsights: 2.0.0 -> 2.1.0`                                  |
| [`f329ced6`](https://github.com/NixOS/nixpkgs/commit/f329ced6f2fac212e341d00a6ff08502b36e7f8d) | `python310Packages.sqlite-utils: 3.22 -> 3.22.1`                                                    |
| [`1b121393`](https://github.com/NixOS/nixpkgs/commit/1b12139305b2db98dc8f2326ae75003645530d40) | `python39Packages.mautrix: 0.14.5 -> 0.14.6`                                                        |
| [`eff0fc08`](https://github.com/NixOS/nixpkgs/commit/eff0fc087cdaeb4360e529d313436ec6bd64f27f) | `python310Packages.sagemaker: 2.73.0 -> 2.74.0`                                                     |
| [`4e8deff9`](https://github.com/NixOS/nixpkgs/commit/4e8deff9c86da7d44c4d38dfb839cf480bd36bf3) | `spot: 0.3.0 -> 0.3.1`                                                                              |
| [`846fafa6`](https://github.com/NixOS/nixpkgs/commit/846fafa68e26d4ea642bbbacd5ea07b9503d75f6) | `lighttpd: 1.4.63 -> 1.4.64`                                                                        |
| [`fa7b83fa`](https://github.com/NixOS/nixpkgs/commit/fa7b83fa48a9567ee81edad1f2ac428a503c56ed) | `python3Packages.objax: fix tensorboard dependency (#156909)`                                       |
| [`13b987ab`](https://github.com/NixOS/nixpkgs/commit/13b987abce920e379b7bf7707fca004f485c3f91) | `linode-cli: 5.14.0 -> 5.15.0`                                                                      |
| [`eeb0e220`](https://github.com/NixOS/nixpkgs/commit/eeb0e220cddb17b00f7f84e25dbd036520c27a22) | `signal-desktop: 5.29.0 -> 5.29.1`                                                                  |
| [`4dc70faa`](https://github.com/NixOS/nixpkgs/commit/4dc70faa6fa89a4dc39f2a74c9631996731ad958) | `twa: 1.9.1 -> 1.10.0`                                                                              |
| [`cf2bdd29`](https://github.com/NixOS/nixpkgs/commit/cf2bdd298b4a406bfe37efb1e9fc37294bad02f1) | `varnish60: 6.0.9 -> 6.0.10`                                                                        |
| [`683d5696`](https://github.com/NixOS/nixpkgs/commit/683d5696e38d777c1743d5b57a2c6d9a2a586457) | `varnish70: 7.0.1 -> 7.0.2`                                                                         |
| [`956dab36`](https://github.com/NixOS/nixpkgs/commit/956dab36a3a8691b851186e9579c7c64dd4aaed5) | `nextcloud: use tmpfiles to create group-readable home`                                             |
| [`7ec99ea7`](https://github.com/NixOS/nixpkgs/commit/7ec99ea7cf9616ef4c6e835710202623fcb846e7) | `qt5.qtwebkit: add disambiguate handle for darwin (#156809)`                                        |
| [`46c42753`](https://github.com/NixOS/nixpkgs/commit/46c427535a72a3bcd32c2e9ff0eafc0e9e399996) | `scribusUnstable: fix build with latest poppler`                                                    |
| [`d8bcc674`](https://github.com/NixOS/nixpkgs/commit/d8bcc674c4bac48aedc7f421fcc2c3d0487a150a) | `gdal: fix build with latest poppler`                                                               |
| [`a18bad9b`](https://github.com/NixOS/nixpkgs/commit/a18bad9ba31880f612d6536611a4daf7f044800d) | `kodi.packages.controller-topology-project: init at unstable-2022-01-22`                            |
| [`c4b98513`](https://github.com/NixOS/nixpkgs/commit/c4b9851332bcef5e4554e306df791b3b4b14409a) | `inkscape: fix build with Poppler 21.11.0`                                                          |
| [`490b9b0f`](https://github.com/NixOS/nixpkgs/commit/490b9b0fa0e7e90ca5bea9cfe79561a97a641530) | `poppler-data: clean up`                                                                            |
| [`8e7c58dc`](https://github.com/NixOS/nixpkgs/commit/8e7c58dc44e043f8629d5e96848ab594f684cbbc) | `poppler: 21.06.1 → 22.01.0`                                                                        |
| [`c1e2f122`](https://github.com/NixOS/nixpkgs/commit/c1e2f122030c560f1e7f167527ce5c0c0c126be8) | `haskellPackages: mark builds failing on hydra as broken`                                           |
| [`a68c4e1d`](https://github.com/NixOS/nixpkgs/commit/a68c4e1d287ed3fecb825934e2de17244d637f23) | `nextcloud-client: 3.4.1 -> 3.4.2`                                                                  |
| [`12c26aca`](https://github.com/NixOS/nixpkgs/commit/12c26aca1fd55ab99f831bedc865a626eee39f80) | `prometheus.exporters.smartctl: Fix autodiscovery`                                                  |
| [`899778e8`](https://github.com/NixOS/nixpkgs/commit/899778e8cf8c8af842a936049650287a168eb649) | `tev: 1.19 -> 1.22`                                                                                 |
| [`5288bcab`](https://github.com/NixOS/nixpkgs/commit/5288bcab0a7cf06ade68ee073ab22cea56e93c66) | `nixos/mx-puppet-discord: Change systemd unit description to avoid newline`                         |
| [`93fb3733`](https://github.com/NixOS/nixpkgs/commit/93fb37332bc9cba892356a33791217da0c7b8f2a) | `exploitdb: 2022-01-25 -> 2022-01-26`                                                               |
| [`1df63801`](https://github.com/NixOS/nixpkgs/commit/1df6380151bebebc1bfc793e790e15a0c4ac6502) | `lsirec: init at unstable-2019-03-03`                                                               |
| [`ddab6418`](https://github.com/NixOS/nixpkgs/commit/ddab64189776da29169fbdc30b9e6c0024ebb43b) | `python3Packages.warcio: init at 1.7.4`                                                             |
| [`83ab260b`](https://github.com/NixOS/nixpkgs/commit/83ab260bbe7e4c27bb1f467ada0265ba13bbeeb0) | `tomboy: remove (#156979)`                                                                          |
| [`9ec1d80c`](https://github.com/NixOS/nixpkgs/commit/9ec1d80c55807213d54548708c52a8c1c9a7df4a) | `nixos/tests/breitbandmessung: use virtualisation.resolution option`                                |
| [`a56682b8`](https://github.com/NixOS/nixpkgs/commit/a56682b80e51912c0c0b35e1efdb90c1725d2b47) | `ashpd-demo: 0.0.1-alpha → 0.2.2`                                                                   |
| [`ee68e7a2`](https://github.com/NixOS/nixpkgs/commit/ee68e7a2a9c8cc97aae3a5e16b7b3ad5bb273a50) | `libshumate: unstable-2021-10-06 → 1.0.0.alpha.1`                                                   |
| [`6896f3be`](https://github.com/NixOS/nixpkgs/commit/6896f3beb7b358b23f9fc485bc36887e0b376630) | `phoronix-test-suite: 10.8.0 -> 10.8.1`                                                             |
| [`b81c67d4`](https://github.com/NixOS/nixpkgs/commit/b81c67d478f952d1f56f93b2771b43583e9f5ee4) | `procs: 0.12.0 -> 0.12.1`                                                                           |
| [`f860b289`](https://github.com/NixOS/nixpkgs/commit/f860b289d4d7a45c38b7dbe8f74bf0d09d86f313) | `prometheus.exporters.smartctl: Allow RAWIO`                                                        |
| [`487aa078`](https://github.com/NixOS/nixpkgs/commit/487aa0781d2151e5be83f0f39f73c3941ba24028) | `breitbandmessung: init at 3.1.0`                                                                   |
| [`3624f96c`](https://github.com/NixOS/nixpkgs/commit/3624f96c70fb20bfd9001402641fcb6313d4723e) | `imagemagick: apply upstream patch to fix perlPackages.ImageMagick`                                 |
| [`4acad300`](https://github.com/NixOS/nixpkgs/commit/4acad300acfe47598322965f574aef9bff711c98) | `Revert "pkgs.path: Avoid copying when used via flake"`                                             |
| [`6b9ef93b`](https://github.com/NixOS/nixpkgs/commit/6b9ef93b98c053ef6390ef96092b3b302773a4aa) | `Revert "flake.nix: Set nixpkgs.config.path"`                                                       |
| [`7e76358a`](https://github.com/NixOS/nixpkgs/commit/7e76358a03cbad49b39cd8fa6da86335cb678a1e) | `linux: 5.4.173 -> 5.4.174`                                                                         |
| [`35ba4ae7`](https://github.com/NixOS/nixpkgs/commit/35ba4ae7a4165854f3bb467e1e41d510a25c866a) | `linux: 5.16.2 -> 5.16.3`                                                                           |
| [`532ede57`](https://github.com/NixOS/nixpkgs/commit/532ede5712e4640d4d11348259d93fff68cfef03) | `linux: 5.15.16 -> 5.15.17`                                                                         |
| [`b14eceed`](https://github.com/NixOS/nixpkgs/commit/b14eceedca3f320ab5d08b8714746c7927827ff5) | `linux: 5.10.93 -> 5.10.94`                                                                         |
| [`7b550563`](https://github.com/NixOS/nixpkgs/commit/7b55056304370c9874bdf10c977e7e30c8ddf850) | `linux: 4.9.297 -> 4.9.298`                                                                         |
| [`c0b2ac9b`](https://github.com/NixOS/nixpkgs/commit/c0b2ac9b7ad6b0ae2b24bee64ade994a3c477ab3) | `linux: 4.4.299 -> 4.4.300`                                                                         |
| [`e0781196`](https://github.com/NixOS/nixpkgs/commit/e0781196f77715c3b703541d17f022d4a346c334) | `linux: 4.19.225 -> 4.19.226`                                                                       |
| [`388633ad`](https://github.com/NixOS/nixpkgs/commit/388633adc53a20ba253f121370459a8d7cead229) | `linux: 4.14.262 -> 4.14.263`                                                                       |
| [`aa877346`](https://github.com/NixOS/nixpkgs/commit/aa877346f8cf9a12da8402d5f7e2097b8136890c) | `Revert "nixos/documentation: avoid copying nixpkgs subpaths, iteration 2"`                         |
| [`647b3043`](https://github.com/NixOS/nixpkgs/commit/647b304306b5d483294754faf1951fe788d060c2) | `Revert "nixos/documentation.nix: Only use store non-flake pkgs.path directly when already copied"` |
| [`a732a8de`](https://github.com/NixOS/nixpkgs/commit/a732a8de1ccb042cc05b1ac7defd7e4c9a91b4ff) | `Revert "nixos/documentation.nix: Use builtins.storePath when appropriate"`                         |
| [`fb2a3e0f`](https://github.com/NixOS/nixpkgs/commit/fb2a3e0fdadc4b83e3bee5f8398e69ca75fd5c30) | `python310Packages.flux-led: 0.28.11 -> 0.28.17`                                                    |