### PR TITLE
chore(flake/nixpkgs): `8cec3cc2` -> `21968db3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1644269936,
-        "narHash": "sha256-Pxn2au1JChCuxiKtmF8hpV7DyvKrCYd0vLzZGjGV0VE=",
+        "lastModified": 1646051047,
+        "narHash": "sha256-XDJGACWVeNs3OAECpx20zegX/YDigHOUZ1nVmCJUeEM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8cec3cc29e2bc2a7dea71de46d3fd4441700de2e",
+        "rev": "21968db378c9144f418c1e8e7002316aa8b75776",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                       |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`ab34433b`](https://github.com/NixOS/nixpkgs/commit/ab34433bc0dcdf9b3cfbc8bb187030920b4c0e7b) | `emojipick: init at 2021-01-27 (#158187)`                                            |
| [`53e70ab7`](https://github.com/NixOS/nixpkgs/commit/53e70ab75490df87a165d704a9e98312b3f5137b) | `maintainers/teams: add minijackson to the beam team`                                |
| [`6a96ddb6`](https://github.com/NixOS/nixpkgs/commit/6a96ddb67509064c2d445b3fae73d4c4c38c539d) | `pkgs-lib: Implement settings format for Elixir`                                     |
| [`3bce8227`](https://github.com/NixOS/nixpkgs/commit/3bce8227a0019104590dfab07d527f7493a9e1f6) | `llvmPackages_14.lld: Update fix-root-src-dir.patch to fix the build`                |
| [`1bdf7862`](https://github.com/NixOS/nixpkgs/commit/1bdf7862e3f8007cdb21bbbde1d496064f869bb3) | `chromiumBeta: Fix the build`                                                        |
| [`c0952b64`](https://github.com/NixOS/nixpkgs/commit/c0952b6478194c01081d338b46402803cbfd14a6) | `chromium{Beta,Dev}: Switch to LLVM 14`                                              |
| [`0d39e18c`](https://github.com/NixOS/nixpkgs/commit/0d39e18c48e9cd709566400774f574dd12d2684c) | `maestral-gui: 1.5.2 -> 1.5.3`                                                       |
| [`1e6f7736`](https://github.com/NixOS/nixpkgs/commit/1e6f7736a2f6f0c30bcc51f4f14bcd4147c26292) | `python3Packages.maestral: 1.5.2 -> 1.5.3`                                           |
| [`39db09d8`](https://github.com/NixOS/nixpkgs/commit/39db09d87bc478ca14cdce86bbfaf6977bb88309) | `python39Packages.bandit: 1.7.2 -> 1.7.3`                                            |
| [`807cf78f`](https://github.com/NixOS/nixpkgs/commit/807cf78f4bbf2aeb72753be46d40b99f4f69878d) | `yq-go: 4.20.2 -> 4.21.1`                                                            |
| [`b8b1c733`](https://github.com/NixOS/nixpkgs/commit/b8b1c733b2397dc3b45333a1c9c2929d69ed6f9f) | `okteta: 0.26.6 -> 0.26.7`                                                           |
| [`de4352ba`](https://github.com/NixOS/nixpkgs/commit/de4352babbbba55e6617a10d9c42a77ec710c31c) | `{lib,}ktorrent: move to pkgs/application/kde`                                       |
| [`a7f2e16a`](https://github.com/NixOS/nixpkgs/commit/a7f2e16a4f9e0cf153866f4a431bc04a108c840a) | `gitlab: 14.7.4 -> 14.8.2 (#162088)`                                                 |
| [`f49a6fea`](https://github.com/NixOS/nixpkgs/commit/f49a6fea32978a555ef15734d729b1cbb8c43413) | `metasploit: 6.1.30 -> 6.1.31`                                                       |
| [`6c39270a`](https://github.com/NixOS/nixpkgs/commit/6c39270a3ab1fc828585c28e5931fca093669b11) | `checkov: 2.0.900 -> 2.0.906`                                                        |
| [`434bdc8e`](https://github.com/NixOS/nixpkgs/commit/434bdc8e4a13f500f35241839ae82e0d8acbff3d) | `skanlite: move to pkgs/application/kde`                                             |
| [`c57495ca`](https://github.com/NixOS/nixpkgs/commit/c57495ca2723eb7802245a51a408f583405c1060) | `vscode-extensions.takayama.vscode-qq: update 1.4.0 -> 1.4.2`                        |
| [`0432d5f1`](https://github.com/NixOS/nixpkgs/commit/0432d5f1dad88c0510386c60c3b9e3ad43f34081) | `jwm: 2.4.0 -> 2.4.1`                                                                |
| [`60840fc6`](https://github.com/NixOS/nixpkgs/commit/60840fc63f3bafa5605c9e5138c2997dfb32d937) | `grype: 0.33.0 -> 0.33.1`                                                            |
| [`8a9421f0`](https://github.com/NixOS/nixpkgs/commit/8a9421f0285d99b1f3cf19eb449a262c8cadf017) | `crystal: add support for passing custom build options when using the shard builder` |
| [`6db4dc07`](https://github.com/NixOS/nixpkgs/commit/6db4dc07c61bfa8670583d586a6477ef070ea717) | `remind: 03.04.00 -> 03.04.01`                                                       |
| [`4884066c`](https://github.com/NixOS/nixpkgs/commit/4884066cf4e32e893414bfbf7173b4e3bbca1e52) | `godns: 2.6 -> 2.7`                                                                  |
| [`e769e730`](https://github.com/NixOS/nixpkgs/commit/e769e73003858b1974aeb79a0317171d4ad100df) | `python310Packages.fastapi: 0.74.0 -> 0.74.1`                                        |
| [`d4de0d56`](https://github.com/NixOS/nixpkgs/commit/d4de0d56282716fcd54a077e80aaa41c567f83b4) | `python310Packages.pyisy: 3.0.2 -> 3.0.3`                                            |
| [`51bbbb19`](https://github.com/NixOS/nixpkgs/commit/51bbbb19ed244d766c0079cfd11b7435f750ad9f) | `python310Packages.slixmpp: 1.7.1 -> 1.8.0.1`                                        |
| [`102c02f4`](https://github.com/NixOS/nixpkgs/commit/102c02f432c5ec2529da3a3c4a65b5074daafc02) | `terraform-providers: update 2022-02-28`                                             |
| [`efa6365c`](https://github.com/NixOS/nixpkgs/commit/efa6365cf6254db27d88eeb2140365c19430cb32) | `python310Packages.spacy-legacy: 3.0.8 -> 3.0.9`                                     |
| [`50e0e124`](https://github.com/NixOS/nixpkgs/commit/50e0e1248290466943b040ea300178ac02497313) | `python310Packages.trimesh: 3.10.1 -> 3.10.2`                                        |
| [`142326c2`](https://github.com/NixOS/nixpkgs/commit/142326c28aa4839dcf029d8bc38befb6e182efbf) | `python310Packages.py3status: 3.40 -> 3.41`                                          |
| [`ee62ae9a`](https://github.com/NixOS/nixpkgs/commit/ee62ae9a6993113581443d0a2eba0ec63f014fa8) | `python310Packages.plexapi: 4.9.2 -> 4.10.0`                                         |
| [`c3dbdb1d`](https://github.com/NixOS/nixpkgs/commit/c3dbdb1d1076830c2244d65180e2d33f841d7ebe) | `python310Packages.pyoverkiz: 1.3.8 -> 1.3.9`                                        |
| [`cc871935`](https://github.com/NixOS/nixpkgs/commit/cc87193562dcb336c986a83f9ba89fca87e76186) | `python310Packages.python-hosts: 1.0.2 -> 1.0.3`                                     |
| [`bbba21ba`](https://github.com/NixOS/nixpkgs/commit/bbba21baaa6f42fe1bd0284cc418cbddadcf379d) | `python310Packages.willow: 1.4 -> 1.4.1`                                             |
| [`f8c560e2`](https://github.com/NixOS/nixpkgs/commit/f8c560e285a175a7a1c571968974d314397bc2bd) | `netdata: fix protobuf support`                                                      |
| [`66691701`](https://github.com/NixOS/nixpkgs/commit/66691701dff52dd85048910e552ae43b8dad7048) | `jetbrains: update (#161186)`                                                        |
| [`158bf609`](https://github.com/NixOS/nixpkgs/commit/158bf609c53ba114d8828dd402813699bc53188f) | `checkip: 0.18.0 -> 0.18.1`                                                          |
| [`1639ba3e`](https://github.com/NixOS/nixpkgs/commit/1639ba3e819abcae801647e89f72c37949261822) | `certipy: 2.0.7 -> 2.0.9`                                                            |
| [`9363ec25`](https://github.com/NixOS/nixpkgs/commit/9363ec256daa0e2b1e51ff124c27e96156d9837c) | `pdf2odt: use resholvePackage`                                                       |
| [`11870cb2`](https://github.com/NixOS/nixpkgs/commit/11870cb2b0880659dfb9faaad6a13503447302c7) | `ccache: 4.5.1 -> 4.6`                                                               |
| [`f73cd879`](https://github.com/NixOS/nixpkgs/commit/f73cd879137938f275513b194d8fdfe14afff499) | `maintainers: remove meutraa`                                                        |
| [`0a800749`](https://github.com/NixOS/nixpkgs/commit/0a8007498f9dba0d5feb191d16317ffa85a9e698) | `bash: use default PATH in FHS environments`                                         |
| [`f0f954ab`](https://github.com/NixOS/nixpkgs/commit/f0f954ab65a76c76668dfd1fa754edd2b2591b92) | `melpa-generated: updated at 2022-02-27`                                             |
| [`a1df6e1b`](https://github.com/NixOS/nixpkgs/commit/a1df6e1ba3e0a26fcc7923d3555ea97d698e36dd) | `python310Packages.pyamg: 4.2.1 -> 4.2.2`                                            |
| [`820d3be4`](https://github.com/NixOS/nixpkgs/commit/820d3be48821a91469aa25536c3596de48ab7d6d) | `k3s: add superherointj to maintainers`                                              |
| [`f79572f9`](https://github.com/NixOS/nixpkgs/commit/f79572f92ff4fa7024aad4c50494318fdb331fe4) | `k3s: update script fixed`                                                           |
| [`56828530`](https://github.com/NixOS/nixpkgs/commit/56828530275888e4d79ee64f8ff772bdbfe34637) | `nixos/release: disable nfs3.simple`                                                 |
| [`fa52a102`](https://github.com/NixOS/nixpkgs/commit/fa52a102be121ea203f4fb4a1fcb403426c0fee5) | `linuxPackages: use 5_10 kernel on i686`                                             |
| [`836c6353`](https://github.com/NixOS/nixpkgs/commit/836c6353cc33fd43e3c956040e77d050a4e6e727) | `linux_5_15: mark as broken on i686`                                                 |
| [`177281ad`](https://github.com/NixOS/nixpkgs/commit/177281ad00b6e5f1b3ba9acced399e2bc7d37340) | `nixos/amazon-image: use 5_10 kernel and add assert`                                 |
| [`881a1092`](https://github.com/NixOS/nixpkgs/commit/881a10922712ae4dbb784d5240728222ea176bf3) | `Revert "Revert "linuxPackages: bump default 5.10 -> 5.15""`                         |
| [`a0abe63e`](https://github.com/NixOS/nixpkgs/commit/a0abe63e440a320323251895d2f6de61e0893d57) | `python310Packages.aiogithubapi: 22.2.3 -> 22.2.4`                                   |
| [`f006f108`](https://github.com/NixOS/nixpkgs/commit/f006f108ab66d49d4755819213be80bd2f9c0d3b) | `python310Packages.APScheduler: 3.8.1 -> 3.9.0.post1`                                |
| [`1300b351`](https://github.com/NixOS/nixpkgs/commit/1300b351a73d9a4792bf7eae9bf8048e46abcd24) | `vscode-extensions.redhat.java: 1.2.0 -> 1.3.0`                                      |
| [`0e734b2f`](https://github.com/NixOS/nixpkgs/commit/0e734b2fe223b3e9dd3cad878ed41738fb6017a3) | `python310Packages.django-dynamic-preferences: 1.11.0 -> 1.12.0`                     |
| [`d91c40a3`](https://github.com/NixOS/nixpkgs/commit/d91c40a3cd423124518a6f7c4a3b7d7b192cf5f8) | `vscode-extensions.llvm-vs-code-extensions.vscode-clangd: 0.1.13 -> 0.1.15`          |
| [`11189a2c`](https://github.com/NixOS/nixpkgs/commit/11189a2cd4224efa55f1402630dba47908178311) | `vimPlugins.vim-CtrlXA: init at 2021-08-09`                                          |
| [`507ab175`](https://github.com/NixOS/nixpkgs/commit/507ab175316c6b1d4510b696182b1af6148aa7ca) | `python3Packages.celery: add nixosTests.sourcehut as passthru test`                  |
| [`899f4107`](https://github.com/NixOS/nixpkgs/commit/899f4107a4ceff0a32b71c648a74970837d0e6ad) | `python3Packages.weconnect-mqtt: 0.29.1 -> 0.30.0`                                   |
| [`74cb03c8`](https://github.com/NixOS/nixpkgs/commit/74cb03c8efd046bde52a915e0403a65b89aea727) | `python3Packages.weconnect: 0.36.4 -> 0.37.0`                                        |
| [`323837f7`](https://github.com/NixOS/nixpkgs/commit/323837f7db75d84672a9d5a2368905b132ef91cf) | `llvmPackages_14: 2022-01-07 -> 14.0.0-rc1`                                          |
| [`0685f53c`](https://github.com/NixOS/nixpkgs/commit/0685f53c66ec580e560cbc04f468bbb3f6d7d5a1) | `python310Packages.hg-evolve: 10.4.1 -> 10.5.0`                                      |
| [`27e7b4d9`](https://github.com/NixOS/nixpkgs/commit/27e7b4d9c754e6595e3c5033b691cadd40b999bf) | `steam: add dotnet support`                                                          |
| [`b3bb79b6`](https://github.com/NixOS/nixpkgs/commit/b3bb79b6b1747755846a3c974b6ca0e865bb05ff) | `aquosctl: init at unstable-2014-04-06`                                              |
| [`6bd94480`](https://github.com/NixOS/nixpkgs/commit/6bd9448062fcb75c55c0fa7adf93d3562aa01734) | `python39Packages.oslo-db: 11.1.0 -> 11.2.0`                                         |
| [`679c50b9`](https://github.com/NixOS/nixpkgs/commit/679c50b9f042bff5c9131b369692f3a95ceb9278) | `nongnu-generated: updated at 2022-02-27`                                            |
| [`abb2cd33`](https://github.com/NixOS/nixpkgs/commit/abb2cd336d25bc769dcd55e4fda5a816fbd62e0f) | `elpa-generated: updated at 2022-02-27`                                              |
| [`b2ffb9fc`](https://github.com/NixOS/nixpkgs/commit/b2ffb9fc96c3b2c1f16112a750da03c82b789760) | `qgis-ltr: add willcohen to maintainers`                                             |
| [`e18d2801`](https://github.com/NixOS/nixpkgs/commit/e18d2801ad5b50bc82e4a42dd083d9795d75966a) | `qgis: add willcohen to maintainers`                                                 |
| [`9f27578b`](https://github.com/NixOS/nixpkgs/commit/9f27578b401813f9355ca3c789e10df872541d7d) | `qgis-ltr: 3.16.16 -> 3.22.4`                                                        |
| [`2448f4dd`](https://github.com/NixOS/nixpkgs/commit/2448f4dd455119cfd272bc6618cbd2db38a86bc7) | `qgis: 3.22.3 -> 3.24.0`                                                             |
| [`22ce0cf3`](https://github.com/NixOS/nixpkgs/commit/22ce0cf3649ca70d026c227d4116ba48d75a894c) | `texworks: 0.6.6 -> 0.6.7`                                                           |
| [`339463b0`](https://github.com/NixOS/nixpkgs/commit/339463b00d7b42c2bd09086386edb4cfd06beb4c) | `python310Packages.python-izone: 1.2.4 -> 1.2.7`                                     |
| [`169ba823`](https://github.com/NixOS/nixpkgs/commit/169ba823d9379e6adec8ff703adb43be5b4e4659) | `cmark-gfm: fix includes`                                                            |
| [`ea7ff89d`](https://github.com/NixOS/nixpkgs/commit/ea7ff89d2cc3790ba087a17d14d807bd04881f8a) | `archivy: 1.6.1 -> 1.7.1`                                                            |
| [`cd1c866d`](https://github.com/NixOS/nixpkgs/commit/cd1c866d87f943c266a315c2cb0bd34a5acd12dd) | `readability-lxml: init at 0.8.1`                                                    |
| [`a9defb71`](https://github.com/NixOS/nixpkgs/commit/a9defb71ed07cc53cc47b9a9da8cf0767b437014) | `python39Packages.fontparts: 0.10.2 -> 0.10.3`                                       |
| [`45cd41de`](https://github.com/NixOS/nixpkgs/commit/45cd41de23593be4ab1da45546b883ef14f3e596) | `llvmPackages_{git,14}: Replace tabs in lld/default.nix`                             |
| [`fbb2eb81`](https://github.com/NixOS/nixpkgs/commit/fbb2eb81f87e113a10c11050b90f25c875f665ea) | `texlab: 3.3.1 -> 3.3.2`                                                             |
| [`c06351b0`](https://github.com/NixOS/nixpkgs/commit/c06351b06e94305f152b53aaa1eb9eb52cdfbda3) | `opentabletdriver: v0.6.0.2 -> v0.6.0.3`                                             |
| [`d61e45b6`](https://github.com/NixOS/nixpkgs/commit/d61e45b686bba959ae361425a47a881a43a56fad) | `llvmPackages_14: init at 2022-01-07`                                                |
| [`e2ba45f5`](https://github.com/NixOS/nixpkgs/commit/e2ba45f5abc7332b07d57d9cb17ea9da3b3a8887) | `llvmPackages_14: Copy the files from llvmPackages_git`                              |
| [`faae760e`](https://github.com/NixOS/nixpkgs/commit/faae760e98c9a17d9604d2b66b8a15a13071f94e) | `llvmPackages_git.llvm: Drop llvm-config-link-static.patch (#162101)`                |
| [`c596cb7c`](https://github.com/NixOS/nixpkgs/commit/c596cb7cb25a60a94f7dc21601497c7fb7fb5f7c) | `omnisharp-roslyn: support Darwin`                                                   |
| [`e1214d5d`](https://github.com/NixOS/nixpkgs/commit/e1214d5d8a959d78b0607d54d9b165b27f68bd54) | `python310Packages.samsungtvws: 1.7.0 -> 2.0.0`                                      |
| [`f04b4d06`](https://github.com/NixOS/nixpkgs/commit/f04b4d064033a7adfb4d1c1838192e63c6239165) | `calibre: 5.34.0 -> 5.37.0`                                                          |
| [`98b8385e`](https://github.com/NixOS/nixpkgs/commit/98b8385e20ee82adce7d2b7d72374efa44226665) | `oven-media-engine: 0.13.0 -> 0.13.1`                                                |
| [`19185e8c`](https://github.com/NixOS/nixpkgs/commit/19185e8ca9f2176242bd7910cbd35e6e7fdd545c) | `du-dust: 0.7.5 -> 0.8.0`                                                            |
| [`64ba26f7`](https://github.com/NixOS/nixpkgs/commit/64ba26f745354ace38e955ca0554b0825c901ce3) | `purescript: 0.14.6 -> 0.14.7`                                                       |
| [`8e97a58b`](https://github.com/NixOS/nixpkgs/commit/8e97a58b5665f9f4eabe7602ac06de16b031a41a) | `okapi: 1.3.0 -> 1.4.0`                                                              |
| [`9a07db13`](https://github.com/NixOS/nixpkgs/commit/9a07db13ca03d93362edb6e6a7ab22813f6f6ba8) | `nfpm: 2.13.0 -> 2.14.0`                                                             |
| [`5668e630`](https://github.com/NixOS/nixpkgs/commit/5668e6309f97e4a35e60bbb21f5d442ac92cb588) | `python310Packages.rpyc: 5.0.1 -> 5.1.0`                                             |
| [`bd61b913`](https://github.com/NixOS/nixpkgs/commit/bd61b9139fac3cd637a91a00b80ec79aeec228a7) | `mob: 2.3.0 -> 2.5.0`                                                                |
| [`0f43432b`](https://github.com/NixOS/nixpkgs/commit/0f43432b55212b0abf58095b18c000e15d1608e0) | `php74Extensions.mongodb: 1.12.0 -> 1.12.1`                                          |
| [`aa23e9cd`](https://github.com/NixOS/nixpkgs/commit/aa23e9cdb4fbe367a7aceee96a00d5865fafeb50) | `minio-client: 2022-02-23T03-15-59Z -> 2022-02-26T03-58-31Z`                         |
| [`d118f55e`](https://github.com/NixOS/nixpkgs/commit/d118f55e2310b29fdb037d900e062705edcb27dd) | `php74Packages.composer: 2.2.6 -> 2.2.7`                                             |
| [`9f064b9d`](https://github.com/NixOS/nixpkgs/commit/9f064b9d541652f8b92fa70b786525b0eacac9d5) | `lfs: 2.1.1 -> 2.2.0`                                                                |
| [`6e389e63`](https://github.com/NixOS/nixpkgs/commit/6e389e63678fe13660bcc9f708649e64eae6bb05) | `nixos/bird: run service as non-root user, add test for reload`                      |
| [`33a22b33`](https://github.com/NixOS/nixpkgs/commit/33a22b332a8743acdc01505b238de9f882657a77) | `python310Packages.motionblinds: 0.5.13 -> 0.6.0`                                    |
| [`78ec9971`](https://github.com/NixOS/nixpkgs/commit/78ec9971a49bc005082d8cb100b484f1d096b42b) | `bat: 0.19.0 -> 0.20.0`                                                              |
| [`eec72b56`](https://github.com/NixOS/nixpkgs/commit/eec72b56d773d0e808d8c95c72290a7f16f12962) | `cataclysm-dda: enable parallel building (#161957)`                                  |
| [`17df62a9`](https://github.com/NixOS/nixpkgs/commit/17df62a9373741f490aacb817c0341704dd5a830) | `shiori: fix NixOS test (#161969)`                                                   |
| [`867bbad5`](https://github.com/NixOS/nixpkgs/commit/867bbad5c295ec1959bb15e6ffa87b4875f840dd) | `gdown: 4.3.1 -> 4.4.0`                                                              |
| [`6e1e1ddf`](https://github.com/NixOS/nixpkgs/commit/6e1e1ddf070a703c51f77ffa7aa176c339dc055a) | `python3Packages.ipython: disable clipboard test on darwin (targeting master)`       |
| [`9e609e9d`](https://github.com/NixOS/nixpkgs/commit/9e609e9d81c0156163e1d0985f5858597fcf79e2) | `rtsp-simple-server: 0.17.8 -> 0.17.17`                                              |
| [`dc23e694`](https://github.com/NixOS/nixpkgs/commit/dc23e69491c746083210618e7b55dd1afb010621) | `python3Packages.tensorflow: 2.7.0 -> 2.7.1 (#161589)`                               |
| [`23380df7`](https://github.com/NixOS/nixpkgs/commit/23380df7de6a417630aa181e7e5bb60fa475d45d) | `randtype: mark as broken on darwin`                                                 |
| [`9d3a2508`](https://github.com/NixOS/nixpkgs/commit/9d3a2508162e770ee90c5fbf17d743ce50986831) | `bazarr: 1.0.2 -> 1.0.3`                                                             |
| [`06e5302e`](https://github.com/NixOS/nixpkgs/commit/06e5302eb5ede88379355afc88d12305f8890d8d) | `apktool: 2.6.0 -> 2.6.1`                                                            |
| [`6fa9f8b5`](https://github.com/NixOS/nixpkgs/commit/6fa9f8b56410b8dc9e3d22b102fd256264a4f94f) | `plexamp: 4.0.2 -> 4.0.3`                                                            |
| [`e0819e3c`](https://github.com/NixOS/nixpkgs/commit/e0819e3c508fea4e4c7903684ecd66ce58a31c02) | `jool: 4.1.6 -> 4.1.7`                                                               |
| [`fe73c827`](https://github.com/NixOS/nixpkgs/commit/fe73c8276aaeea3f05c6d8090bbc34a592ad77a6) | `libtracefs: 1.2.5 -> 1.3.0`                                                         |
| [`d1418cce`](https://github.com/NixOS/nixpkgs/commit/d1418cce93da4c3fb5d2a419ada82d20f77e24c5) | `velero: 1.7.1 -> 1.8.0`                                                             |
| [`e517d280`](https://github.com/NixOS/nixpkgs/commit/e517d280c01521b15795c9b493fc1e7c911fd3bd) | `libtraceevent: 1.5.0 -> 1.5.1`                                                      |
| [`0dadec45`](https://github.com/NixOS/nixpkgs/commit/0dadec45d805c31a0cff3d1ea4e0a3e9a357edfe) | `logrotate/systemd: add 'minsize = 1M' to wtmp/btmp rotation`                        |
| [`953c9a5d`](https://github.com/NixOS/nixpkgs/commit/953c9a5d6e162ee35455f13b77d2c4d279356223) | `coreboot-toolchain: 4.15 -> 4.16`                                                   |
| [`005a18f6`](https://github.com/NixOS/nixpkgs/commit/005a18f6bda9376fe8f92b324db4ac05cd5387de) | `hepmc3: 3.2.4 -> 3.2.5`                                                             |
| [`c267e9ce`](https://github.com/NixOS/nixpkgs/commit/c267e9ce37dd2f2f9975ab83c538a624f1fede50) | `mumble,murmur: 1.3.4 -> 1.4.231`                                                    |
| [`b438b68c`](https://github.com/NixOS/nixpkgs/commit/b438b68cb495e48f104e4f87ac28ef52c6e7b3cd) | `python3Packages.zcs: patch to fix the test`                                         |
| [`f2943856`](https://github.com/NixOS/nixpkgs/commit/f29438562f9693f724e022e1fe0196ad983bdf6f) | `nextcloud-client: add xdg-utils`                                                    |
| [`cc0b1fdd`](https://github.com/NixOS/nixpkgs/commit/cc0b1fddcdd9a55005d18ecee6fc30eabc89d156) | `python3Packages.mlflow: 1.22.0 -> 1.23.1`                                           |
| [`154e13a5`](https://github.com/NixOS/nixpkgs/commit/154e13a556984f1aa2f88b6c866a8370cf21af1a) | `chromiumDev: 100.0.4892.0 -> 100.0.4896.12`                                         |
| [`05b2b4e3`](https://github.com/NixOS/nixpkgs/commit/05b2b4e3cbfa23926cb30ffab16d2f2409a1b6c0) | `chromiumBeta: 99.0.4844.35 -> 99.0.4844.45`                                         |
| [`d4096ffd`](https://github.com/NixOS/nixpkgs/commit/d4096ffd0a36e5600906cad6deca864a0c9b01db) | `mpd-discord-rpc: 1.4.0 -> 1.4.1`                                                    |
| [`6431bebc`](https://github.com/NixOS/nixpkgs/commit/6431bebc93b6ce35f98d9c6d1b09975126a391d8) | `mesa: Limit the devDoesNotDependOnLLVM test to Linux`                               |
| [`2bdadac1`](https://github.com/NixOS/nixpkgs/commit/2bdadac12312a5078fea298b94d5ac1d50337e2d) | `python310Packages.ibm-cloud-sdk-core: 3.14.0 -> 3.15.0`                             |
| [`1827d631`](https://github.com/NixOS/nixpkgs/commit/1827d6315a8a6862e9bb40f1bc554045efd95065) | `uncrustify: 0.72.0 -> 0.74.0`                                                       |
| [`c9fa0313`](https://github.com/NixOS/nixpkgs/commit/c9fa03136ad26fab9c5d4d62c57fc26e2d5dc9e5) | `or-tools: disable parallel-building`                                                |
| [`464bb0bb`](https://github.com/NixOS/nixpkgs/commit/464bb0bb59a27f311441429fa99167de3f300ae8) | `evolution-ews: 3.42.3 -> 3.42.4`                                                    |
| [`0b77e65f`](https://github.com/NixOS/nixpkgs/commit/0b77e65fa61c5b20b973b42952f0051f8cacdf43) | `html-xml-utils: 8.2 -> 8.3`                                                         |
| [`35c1b68c`](https://github.com/NixOS/nixpkgs/commit/35c1b68c8640f2a22ee925c903bfc29d5c125259) | `lfs: 2.1.0 -> 2.1.1`                                                                |