### PR TITLE
chore(flake/utils): `a4b154eb` -> `1ed9fb19`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -45,11 +45,11 @@
     },
     "utils": {
       "locked": {
-        "lastModified": 1649676176,
-        "narHash": "sha256-OWKJratjt2RW151VUlJPRALb7OU2S5s+f0vLj4o1bHM=",
+        "lastModified": 1653893745,
+        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "a4b154ebbdc88c8498a5c7b01589addc9e9cb678",
+        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                               | Commit Message                                                                   |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`1ed9fb19`](https://github.com/numtide/flake-utils/commit/1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1) | `Fix check-utils template directory name (#70)`                                  |
| [`04c1b180`](https://github.com/numtide/flake-utils/commit/04c1b180862888302ddfb2e3ad9eaa63afc60cf8) | `feat: add convenience eachDefaultSystemMap (#60)`                               |
| [`a97445c4`](https://github.com/numtide/flake-utils/commit/a97445c4fcd22ca0d1d5a969972eb24bc819ff3a) | `expose examples as templates (#63)`                                             |
| [`04b4d989`](https://github.com/numtide/flake-utils/commit/04b4d989fda8f14e6fcd1fee631eab9c54d15b97) | `Sanitize the final derivation name to ensure length limits are respected (#66)` |
| [`86115ca0`](https://github.com/numtide/flake-utils/commit/86115ca06b809e102962f1288e0de0ed0822a2a0) | `allSystems: sync with nixpkgs`                                                  |
| [`0d347c56`](https://github.com/numtide/flake-utils/commit/0d347c56f6f41de822a4f4c7ff5072f3382db121) | `use defaultSystems in simpleFlake.nix`                                          |
| [`eca9b1aa`](https://github.com/numtide/flake-utils/commit/eca9b1aae05b7a7957839eb2e2be08e085c6f037) | `Bump actions/checkout from 2 to 3`                                              |