### PR TITLE
chore(flake/gitignore): `bff2832e` -> `f2ea0f8f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1646480205,
-        "narHash": "sha256-kekOlTlu45vuK2L9nq8iVN17V3sB0WWPqTTW3a2SQG0=",
+        "lastModified": 1658402513,
+        "narHash": "sha256-wk38v/mbLsOo6+IDmmH1H0ADR87iq9QTTD1BP9X2Ags=",
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
-        "rev": "bff2832ec341cf30acb3a4d3e2e7f1f7b590116a",
+        "rev": "f2ea0f8ff1bce948ccb6b893d15d5ea3efaf1364",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                     | Commit Message                            |
| ---------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`e42bb748`](https://github.com/hercules-ci/gitignore.nix/commit/e42bb748f3947d3264c38f84883422ffa4300e74) | `Disable globalIgnores when in pure mode` |
| [`cbafce84`](https://github.com/hercules-ci/gitignore.nix/commit/cbafce846580d04147f4e093d85436170792e898) | `Update find-files.nix`                   |
| [`f0e98c8e`](https://github.com/hercules-ci/gitignore.nix/commit/f0e98c8e42c2bf2ab93241f2556e24a01cffe1f2) | `Add support for pure evaluation mode`    |