### PR TITLE
chore(flake/nixpkgs): `f72be3af` -> `2fcc03de`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1656585567,
-        "narHash": "sha256-i+IY2Dklg3WhIl43iznyAdwtNi7xuIgMUdpJPn3uRuU=",
+        "lastModified": 1659286181,
+        "narHash": "sha256-NKfh0NS1EnLw3LnyQbJsz5zHg/NIUoZBe1tsWhJwzpc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f72be3af76fb7dc45e2088d8cb9aba1e6767a930",
+        "rev": "2fcc03deb192f2af9339b3cda9b18ed53c4443a2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                   |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`ac35f25d`](https://github.com/NixOS/nixpkgs/commit/ac35f25d0d9f91e5cf37b4ec1a00471f431d89a5) | `vimPlugins.hare-vim: init at 2022-07-02`                        |
| [`70fa299e`](https://github.com/NixOS/nixpkgs/commit/70fa299edfec2ea62d60aadae8fe4a3434a2421e) | `signal-cli: 0.10.9 -> 0.10.10`                                  |
| [`8e31bf7b`](https://github.com/NixOS/nixpkgs/commit/8e31bf7beb67a94fa9fbfa8a7a157c3229c44372) | `python310Packages.pytest-subtesthack: 0.1.2 -> 0.2.0`           |
| [`f3b0df8a`](https://github.com/NixOS/nixpkgs/commit/f3b0df8ab83c1590932f46831a579ea2708133d5) | `python3Packages.opensimplex: 0.4.2 -> 0.4.3`                    |
| [`4c3caca9`](https://github.com/NixOS/nixpkgs/commit/4c3caca96dc1b7fa9f0fce9e1a3285f748fb94a4) | `snakemake: 7.9.0 -> 7.12.0`                                     |
| [`98ef7782`](https://github.com/NixOS/nixpkgs/commit/98ef77824c5ecdd0d571fc524527b15619048d76) | `httm: 0.13.4 -> 0.14.7`                                         |
| [`2cd793dd`](https://github.com/NixOS/nixpkgs/commit/2cd793dda0dfd3723947d8817bfd75b64e1e7a03) | `worker-build: 0.0.9 -> 0.0.10`                                  |
| [`56a0b09f`](https://github.com/NixOS/nixpkgs/commit/56a0b09f9bae3c232ea504351cf92d9f11da47a5) | `vcluster: add berryp as maintainer`                             |
| [`4f2f0ac6`](https://github.com/NixOS/nixpkgs/commit/4f2f0ac6ee823e82ddb333f6715a9f9b8bcdd722) | `neil: 0.0.31 -> 0.1.36`                                         |
| [`24678493`](https://github.com/NixOS/nixpkgs/commit/2467849361a7be63724495e1e83afd5299481642) | `vim: 9.0.0057 -> 9.0.0115`                                      |
| [`ea836299`](https://github.com/NixOS/nixpkgs/commit/ea836299d64582ea12bbdeb89dfa0c09dd008061) | `protoc-gen-rust: init at 3.1.0`                                 |
| [`33c5f1b8`](https://github.com/NixOS/nixpkgs/commit/33c5f1b8315d2edec8f02f6bf337ee85b146e896) | `taskwarrior-tui: 0.22.0 -> 0.23.5`                              |
| [`b5a565c9`](https://github.com/NixOS/nixpkgs/commit/b5a565c95160a2dd36c5bfe954972d5ca9231621) | `unison: 2.52.0 -> 2.52.1`                                       |
| [`9dd6ec45`](https://github.com/NixOS/nixpkgs/commit/9dd6ec456b934e1cc3452f001d4f4ef32a774a39) | `gscrabble: mark as broken`                                      |
| [`3de6a330`](https://github.com/NixOS/nixpkgs/commit/3de6a330bcd434d59901c9c7f8fbe252e2207e22) | `go, buildGo{Module,Package}: put top-level attributes together` |
| [`06e270fd`](https://github.com/NixOS/nixpkgs/commit/06e270fd51daaf872382ad75a5f7a5607d9a87a8) | `buildGoModule: prefer verbose output when NIX_DEBUG set`        |
| [`439b1479`](https://github.com/NixOS/nixpkgs/commit/439b147934954e9fe178d81af6d524b06daacfae) | `awscli2: 2.7.14 -> 2.7.20`                                      |
| [`8f585b65`](https://github.com/NixOS/nixpkgs/commit/8f585b658b619c77566eb7d1be1620f2aba404c7) | `geoserver: 2.21.0 -> 2.21.1`                                    |
| [`acbab233`](https://github.com/NixOS/nixpkgs/commit/acbab233f94a5c34f610dd69d4c558b85eea5f76) | `dbx: use non-aliased variant of library`                        |
| [`cb83d392`](https://github.com/NixOS/nixpkgs/commit/cb83d392fe8490454a1c4a5b6be1da88f0d921ff) | `dbx: 0.5.0 -> 0.6.8`                                            |
| [`2099b754`](https://github.com/NixOS/nixpkgs/commit/2099b7545c90ae5962690db04e95280cd013b17f) | `gmime3: 3.2.11 -> 3.2.12`                                       |
| [`7f0dd61e`](https://github.com/NixOS/nixpkgs/commit/7f0dd61eb7e2955f9b50e8dc81f133d64d4e6bce) | `pip-audit: 2.4.2 -> 2.4.3`                                      |
| [`776957cd`](https://github.com/NixOS/nixpkgs/commit/776957cd890ea3189cb8786431b92242ea4e8399) | `python310Packages.nose2: 0.11.0 -> 0.12.0`                      |
| [`137e5dbe`](https://github.com/NixOS/nixpkgs/commit/137e5dbe10096f51c7ff718c5439b73a599ab1d4) | `python310Packages.azure-mgmt-recoveryservices: 2.0.0 -> 2.1.0`  |
| [`1fa5fdc8`](https://github.com/NixOS/nixpkgs/commit/1fa5fdc89890157005ea06b0b5378f6489afdd67) | `grails: 5.1.9 -> 5.2.1`                                         |
| [`762e2106`](https://github.com/NixOS/nixpkgs/commit/762e2106982340407263c6d3d86a7f33de2616ea) | `z88dk: 2.1 -> 2.2`                                              |
| [`9bb7a4d0`](https://github.com/NixOS/nixpkgs/commit/9bb7a4d0e9e7e649b9a0d23e9641b3eed64e9557) | `zsh-nix-shell: 0.4.0 -> 0.5.0`                                  |
| [`0cbb2d14`](https://github.com/NixOS/nixpkgs/commit/0cbb2d14a93642a570f80421869f3a08d2e813bd) | `kapp: 0.46.0 -> 0.50.0`                                         |
| [`d3401db6`](https://github.com/NixOS/nixpkgs/commit/d3401db627b847055093720bf78cdbf44985bf6b) | `z-lua: 1.8.14 -> 1.8.16`                                        |
| [`b417540d`](https://github.com/NixOS/nixpkgs/commit/b417540d5a5e1c51223b68193fdf61d3debb88ad) | `xmrig-mo: 6.16.5-mo1 -> 6.18.0-mo1`                             |
| [`9e158f95`](https://github.com/NixOS/nixpkgs/commit/9e158f95539e946190a1e905721ca540ee9f3d84) | `xmrig: 6.17.0 -> 6.18.0`                                        |
| [`75e6f8eb`](https://github.com/NixOS/nixpkgs/commit/75e6f8eb6f42aa75e4ae31db33c65715a0c106bd) | `xssproxy: 1.0.0 -> 1.0.1`                                       |
| [`fcc7cbce`](https://github.com/NixOS/nixpkgs/commit/fcc7cbce72b83f0e6656451b75e7760017867cec) | `wrangler: 1.19.11 -> 1.19.12`                                   |
| [`c3757625`](https://github.com/NixOS/nixpkgs/commit/c37576257bbf832d3857863b1cefaa7ce6528ead) | `workcraft: 3.3.6 -> 3.3.8`                                      |
| [`cf5b108a`](https://github.com/NixOS/nixpkgs/commit/cf5b108ae72c62ebd2a2c0024494c8e2feaad96f) | `werf: 1.2.140 -> 1.2.144`                                       |
| [`b40fa676`](https://github.com/NixOS/nixpkgs/commit/b40fa67604b71b6e1113af1606e42b55be185c2f) | `wasmer: 2.1.1 -> 2.3.0`                                         |
| [`f148e260`](https://github.com/NixOS/nixpkgs/commit/f148e260488ab7a6ac3a643b479f0b287e880d16) | `wasm-pack: 0.10.2 -> 0.10.3`                                    |
| [`e835aaa7`](https://github.com/NixOS/nixpkgs/commit/e835aaa789af70e466ba6e0304d1eab18a8d16d3) | `vale: 2.20.0 -> 2.20.1`                                         |
| [`4de14540`](https://github.com/NixOS/nixpkgs/commit/4de14540751c3603b88cffd9690d2df677e152e8) | `unpackerr: 0.10.0 -> 0.10.1`                                    |
| [`b2544f13`](https://github.com/NixOS/nixpkgs/commit/b2544f1301520be456fc33d296e6c9a5f6126391) | `terraform-providers: update 2022-07-31`                         |
| [`784a28af`](https://github.com/NixOS/nixpkgs/commit/784a28af407e51f37abe3a076a7c60bbf7ca0fe9) | `strawberry: 1.0.5 -> 1.0.7`                                     |
| [`7db1e3ba`](https://github.com/NixOS/nixpkgs/commit/7db1e3ba67a33d553c26878ec30f32fa9965c358) | `ucx: 1.12.1 -> 1.13.0`                                          |
| [`e22e418e`](https://github.com/NixOS/nixpkgs/commit/e22e418eca18ee5a799ea0aeefa9f8fa8adce600) | `tut: 1.0.14 -> 1.0.15`                                          |
| [`5e02a062`](https://github.com/NixOS/nixpkgs/commit/5e02a06208eddf8d92d175cf53fd61df7f98c604) | `ttyper: 0.4.1 -> 0.4.3`                                         |
| [`4c7fff30`](https://github.com/NixOS/nixpkgs/commit/4c7fff307d3439bf56413860f03faf58dd295588) | `trivy: 0.30.0 -> 0.30.4`                                        |
| [`1f1ba53b`](https://github.com/NixOS/nixpkgs/commit/1f1ba53b11d6200f8eb06aba2cf950be9681cd53) | `trinsic-cli: 1.5.0 -> 1.6.0`                                    |
| [`a071ead1`](https://github.com/NixOS/nixpkgs/commit/a071ead1ae8fe5698315e281d6a3a18259a09a04) | `trillian: 1.4.0 -> 1.4.2`                                       |
| [`ac869ded`](https://github.com/NixOS/nixpkgs/commit/ac869dedaf56800c85f0c9f930fc654156260b28) | `thanos: 0.25.2 -> 0.27.0`                                       |
| [`eabdeadc`](https://github.com/NixOS/nixpkgs/commit/eabdeadceaee1000a7378143a426d6f8df999cf4) | `tfswitch: 0.13.1275 -> 0.13.1288`                               |
| [`bf4cd8c2`](https://github.com/NixOS/nixpkgs/commit/bf4cd8c2c1cfc56f3b35dbbdee0815b33aa29942) | `tfplugindocs: 0.9.0 -> 0.13.0`                                  |
| [`d26a815c`](https://github.com/NixOS/nixpkgs/commit/d26a815cc0caf8883e75bd00c8928e97c3eaa69b) | `tflint: 0.39.0 -> 0.39.1`                                       |
| [`3cc01e78`](https://github.com/NixOS/nixpkgs/commit/3cc01e7860ccba3eb8d3df695e072b35591c2797) | `terraformer: 0.8.19 -> 0.8.21`                                  |
| [`dd121d6b`](https://github.com/NixOS/nixpkgs/commit/dd121d6b8f64d203e4ecd00444a99e0242cbfe8e) | `temporal: 1.16.2 -> 1.17.1`                                     |
| [`9b3be9e3`](https://github.com/NixOS/nixpkgs/commit/9b3be9e3d1c8a3154d0321808f9926c03d842e6e) | `syncthingtray: 1.1.20 -> 1.2.1`                                 |
| [`cfdd884e`](https://github.com/NixOS/nixpkgs/commit/cfdd884efd10042127ed7c12c1df8ff2b0f6698c) | `symfony-cli: 5.4.5 -> 5.4.12`                                   |
| [`a5c0e67e`](https://github.com/NixOS/nixpkgs/commit/a5c0e67ed47a51d0f68b2536af00be42b1d41273) | `stella: 6.6 -> 6.7`                                             |
| [`d1c11328`](https://github.com/NixOS/nixpkgs/commit/d1c11328a42446fa78b141a6ba72062cc278e9d0) | `python3Packages.ansible-runner: avoid test coverage`            |
| [`79d2a9f6`](https://github.com/NixOS/nixpkgs/commit/79d2a9f62ffdd292f2addf22ad6ad8e37751acfb) | `python39Packages.ansible-core: 2.13.1 -> 2.13.2`                |
| [`98d75d6d`](https://github.com/NixOS/nixpkgs/commit/98d75d6d58fdb9237d7888ee04348bb9353047ca) | `spire: 1.3.1 -> 1.3.3`                                          |
| [`f7f301f0`](https://github.com/NixOS/nixpkgs/commit/f7f301f0fb36c72f22d34aa2f58d31b5178c7dfd) | `pythonPackage.liblarch: 3.0.1 -> 3.2.0`                         |
| [`3aaf8bb3`](https://github.com/NixOS/nixpkgs/commit/3aaf8bb3e57000685a56409496e7948ac9414d3b) | `python3Packages.mistune_2_0: 2.0.2 -> 2.0.4`                    |
| [`f7599cdb`](https://github.com/NixOS/nixpkgs/commit/f7599cdb3729fed8075c11365f1cb4370229a212) | `python310Packages.pyperf: 2.3.1 -> 2.4.0`                       |
| [`f6e857bc`](https://github.com/NixOS/nixpkgs/commit/f6e857bccb571719684a22b35b3b78f7d67a8804) | `maestral: fix tests`                                            |
| [`40d72b38`](https://github.com/NixOS/nixpkgs/commit/40d72b38c5eb2cf79ad2a53dc23a177582674caa) | `python310Packages.pudb: 2022.1.1 -> 2022.1.2`                   |
| [`dd91058d`](https://github.com/NixOS/nixpkgs/commit/dd91058dd6c33aab8de94bc206c6f836ccafdb2c) | `ares: 128 -> 129`                                               |
| [`b4136b66`](https://github.com/NixOS/nixpkgs/commit/b4136b66e77543010ddfae49abb839040cc5c49f) | `okteto: 2.5.1 -> 2.5.2`                                         |
| [`6de6568b`](https://github.com/NixOS/nixpkgs/commit/6de6568b66a9956575a11f12d8c7dfa4ae00751c) | `nfpm: 2.16.0 -> 2.17.0`                                         |
| [`7b9be38c`](https://github.com/NixOS/nixpkgs/commit/7b9be38c7250b22d829ab6effdee90d5e40c6e5c) | `treewide: remove myself as maintainer`                          |
| [`f5910772`](https://github.com/NixOS/nixpkgs/commit/f5910772e59efe2bb28e5fb60457978614ebc8e8) | `pulumi-bin: install shell completion`                           |
| [`eabe2192`](https://github.com/NixOS/nixpkgs/commit/eabe2192ea8b277a4aaf438c8b39858230ae31a0) | `pulumi-bin: 3.35.2 -> 3.37.2`                                   |
| [`fc9e5536`](https://github.com/NixOS/nixpkgs/commit/fc9e553653b9becaf4f678cd5d5eed493397e020) | `gitea: 1.16.9 -> 1.17.0`                                        |
| [`befaa616`](https://github.com/NixOS/nixpkgs/commit/befaa6164a92a8a655ac0801c7f145b99181dbe6) | `godns: 2.8.6 -> 2.8.7`                                          |
| [`f5a14e16`](https://github.com/NixOS/nixpkgs/commit/f5a14e169e305b9295e4c63b0dbc5d561e923649) | `python3Packages.protonvpn-nm-lib: 3.10.0 -> 3.11.0`             |
| [`b6da1d81`](https://github.com/NixOS/nixpkgs/commit/b6da1d8198e47033027750440551b4ff427068dd) | `nixos/tests/k3s: add multi-node test`                           |
| [`aa579635`](https://github.com/NixOS/nixpkgs/commit/aa579635b9ded3164dd592b709a8c64aa67eaa0e) | `nixos/tests/k3s: wait for default service account in test`      |
| [`d5b1e257`](https://github.com/NixOS/nixpkgs/commit/d5b1e25711c3451de8f6df7cb4c9148d7aed64c6) | `nixos/tests/k3s: reorganize test into a subdirectory`           |
| [`717f05b6`](https://github.com/NixOS/nixpkgs/commit/717f05b6ce2885c8fbb422305f94af20554ce442) | `wapm-cli: init at 0.5.5 (#183477)`                              |
| [`ecdacf3d`](https://github.com/NixOS/nixpkgs/commit/ecdacf3d46d69f48d3df0f5b9bdeb4fbafb9c451) | `pgadmin: remove all version constraints`                        |
| [`745dcc42`](https://github.com/NixOS/nixpkgs/commit/745dcc426ceae8ae8de583aa7f5840b623d2ab5d) | `greenfoot: 3.7.0 -> 3.7.1`                                      |
| [`f8f42834`](https://github.com/NixOS/nixpkgs/commit/f8f428346e5162c404d624f65809225188ee0972) | `flyway: 9.0.2 -> 9.0.4`                                         |
| [`21aeda0e`](https://github.com/NixOS/nixpkgs/commit/21aeda0e3783a80033cb91a8611fbe7842ca2d38) | `fwupd-efi: 1.2 -> 1.3`                                          |
| [`d49fe728`](https://github.com/NixOS/nixpkgs/commit/d49fe72888413ed73c9e2973c549ceba50821451) | `obsidian: 0.14.15 -> 0.15.9`                                    |
| [`cc8cefb0`](https://github.com/NixOS/nixpkgs/commit/cc8cefb0a8e467a5b2233220358b5d841b91b22c) | `free42: 3.0.9 -> 3.0.13`                                        |
| [`070ce98d`](https://github.com/NixOS/nixpkgs/commit/070ce98ddaa40c86aa0d72f868b155a62bc2d360) | `seahub: build python path from overridden python`               |
| [`c2d6628a`](https://github.com/NixOS/nixpkgs/commit/c2d6628ae97439b92a15ff2c3b0757add493a267) | `seahub: add passthru.tests`                                     |
| [`dd8386c4`](https://github.com/NixOS/nixpkgs/commit/dd8386c453dfa97be3f3a61892da6dc7e9685e53) | `nixos/seafile: version 9.0x compatibility`                      |
| [`8d6df4d0`](https://github.com/NixOS/nixpkgs/commit/8d6df4d03279ae49b09001abfe86bd5fbbad4a60) | `seahub: 8.0.8 -> 9.0.6`                                         |
| [`bc9ec95b`](https://github.com/NixOS/nixpkgs/commit/bc9ec95b3609e6655c38ff09cfa340b671b1c634) | `seafile-server: 8.0.8 -> 9.0.6`                                 |
| [`8e078933`](https://github.com/NixOS/nixpkgs/commit/8e078933f10fe8bed636f9d613fcc0ff974f69c5) | `zen-kernels: 5.18.14 -> 5.18.15`                                |
| [`f6d7bf03`](https://github.com/NixOS/nixpkgs/commit/f6d7bf0315b59728ea4c6329287a2c2a5cd71223) | `stunnel: 5.64 -> 5.65 (#183617)`                                |
| [`153bfc99`](https://github.com/NixOS/nixpkgs/commit/153bfc996609745cd8996400575b0ec3033036dd) | `treewide: use isx86 where appropriate`                          |
| [`5330c0a1`](https://github.com/NixOS/nixpkgs/commit/5330c0a1afe9d97d6f6366157cf0d3da9a8e7c31) | `treewide: use isAarch where appropriate`                        |
| [`b62eadf3`](https://github.com/NixOS/nixpkgs/commit/b62eadf3b1d4d6ff1a40dce0e5eb59d93886b39d) | `dxa: 0.1.4 -> 0.1.5`                                            |
| [`096731db`](https://github.com/NixOS/nixpkgs/commit/096731dbb6f8f9dfb0b638a14a82b0f42dc40dc0) | `redis-plus-plus: remove linux-only restriction`                 |
| [`b25178c7`](https://github.com/NixOS/nixpkgs/commit/b25178c77eed916713267ff0b7cb8c171c85402b) | `ccls: 0.20210330 -> 0.20220729`                                 |
| [`7efdfc2a`](https://github.com/NixOS/nixpkgs/commit/7efdfc2a593457210e6ea0f378db8d990f7c8249) | `proot: 5.3.0 -> 5.3.1, drop libarchive dependency (#183747)`    |
| [`57627e47`](https://github.com/NixOS/nixpkgs/commit/57627e479ee321defba08b121c1def371ba9cdea) | `closurecompiler: 20220601 -> 20220719`                          |
| [`c54facc0`](https://github.com/NixOS/nixpkgs/commit/c54facc0ffa39c6d1d176bb73e1e9ac6e33206a9) | `checkSSLCert: 2.35.0 -> 2.36.0`                                 |
| [`62af94c2`](https://github.com/NixOS/nixpkgs/commit/62af94c2ce5b43e4d56d3817f801cb87807b3660) | `astroid: patch to fix missing icon bug`                         |
| [`c3980a57`](https://github.com/NixOS/nixpkgs/commit/c3980a57329fe2240bab8bc54fe8cb66431d7af9) | `seaweedfs: drop myself as maintainer`                           |
| [`db127e82`](https://github.com/NixOS/nixpkgs/commit/db127e82d85a3b899665e6be1776df389e52849a) | `sfz: init at 0.7.0 (#183911)`                                   |
| [`0426ccf7`](https://github.com/NixOS/nixpkgs/commit/0426ccf7845d48cf49008446871e1636a0a63fd0) | `virtualbox: 6.1.34 -> 6.1.36`                                   |
| [`ff519d50`](https://github.com/NixOS/nixpkgs/commit/ff519d504c7469b36ddffd5bc04c4ff485cbb7df) | `sonic-pi: 3.3.1 -> 4.0.3`                                       |
| [`bd95ace2`](https://github.com/NixOS/nixpkgs/commit/bd95ace2d31564c0caceda68a8c2ec1b97f7116e) | `bitcoin: fix broken build on aarch64-darwin`                    |
| [`1372f30f`](https://github.com/NixOS/nixpkgs/commit/1372f30f9af35f8633fdeafa1d286612046114a5) | `herbstluftwm: 0.9.4 -> 0.9.5`                                   |
| [`e6550076`](https://github.com/NixOS/nixpkgs/commit/e6550076a6c693993a0737a09a7f7c6f28414338) | `python310Packages.statmake: Enable more tests`                  |
| [`33c199ae`](https://github.com/NixOS/nixpkgs/commit/33c199aee4b3bbb31b2d7fb12b20c6419e9f2455) | `babashka: 0.9.159 -> 0.9.160`                                   |