### PR TITLE
chore(flake/nixpkgs): `e462c917` -> `3934dbde`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1696589439,
-        "narHash": "sha256-Ye+flokLfswVz9PZEyJ5yGJ1VqmJe3bDgwWt9Z4MuqQ=",
+        "lastModified": 1701368325,
+        "narHash": "sha256-3OqZyi2EdopJxpxwrySPyCTuCvfBY4oXTLVgQ4B6qDg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e462c9172c685f0839baaa54bb5b49276a23dab7",
+        "rev": "3934dbde4f4a0e266825348bc4ad1bdd00a8d6a3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                        |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`d3ccd1aa`](https://github.com/NixOS/nixpkgs/commit/d3ccd1aa2fc906dd71d44b29dc9b7817c05cfa03) | `` nixos/sysctl: Move changelog entry for yama ``                              |
| [`9c4dd01d`](https://github.com/NixOS/nixpkgs/commit/9c4dd01dea631e494d46885a0a8f64bd7bbbbefc) | `` screenly-cli: init at 0.2.3 ``                                              |
| [`bb9f1fc4`](https://github.com/NixOS/nixpkgs/commit/bb9f1fc46e188a24e4f1abe342f214c37c9c7eb1) | `` ocamlPackages.fiber: unstable-2023-02-28 -> 3.7.0 ``                        |
| [`2e2c8f6f`](https://github.com/NixOS/nixpkgs/commit/2e2c8f6fb7e5ebfe579bc0df2df481edf191030c) | `` clightning: 23.08.1 -> 23.11 ``                                             |
| [`4a59f5a8`](https://github.com/NixOS/nixpkgs/commit/4a59f5a8752c48df6b8ac029b152c7c582652752) | `` pocketbase: add passthru.updateScript ``                                    |
| [`bfdc9aed`](https://github.com/NixOS/nixpkgs/commit/bfdc9aedd598c85ab25b5529968cc2faca167b0f) | `` python310Packages.cssbeautifier: 1.14.9 -> 1.14.11 ``                       |
| [`d266f6f9`](https://github.com/NixOS/nixpkgs/commit/d266f6f91b3fa177b7cde84c9bae66d9cf502e5e) | `` firefox-unwrapped: 120.0 -> 120.0.1 ``                                      |
| [`410698c7`](https://github.com/NixOS/nixpkgs/commit/410698c71a787e38fc40092d73eba52d13864101) | `` materia-theme: fix build ``                                                 |
| [`4739e28e`](https://github.com/NixOS/nixpkgs/commit/4739e28eb1ad7e474ebbe051850f7d2b9340d377) | `` fts: set to musl-fts on musl ``                                             |
| [`0d44b5b7`](https://github.com/NixOS/nixpkgs/commit/0d44b5b7733e35fe17b34921c611c21f805068a9) | `` pkgsStatic.stdenv: fix custom CMake LINKER_LANGUAGE ``                      |
| [`4552f3aa`](https://github.com/NixOS/nixpkgs/commit/4552f3aa254e5c50406ca59c2c04483ef8539161) | `` direnv: 2.32.3 -> 2.33.0 (#271059) ``                                       |
| [`ed48ad7b`](https://github.com/NixOS/nixpkgs/commit/ed48ad7b256ba45209d4d3e6ee641706faccb0e0) | `` teeworlds: fix meta.license ``                                              |
| [`34da65ba`](https://github.com/NixOS/nixpkgs/commit/34da65ba2a6fc0e0c6c54397a4aaab4213ec2c72) | `` gcc6: don’t link libstdc++ to CoreFoundation ``                             |
| [`bcb34ba8`](https://github.com/NixOS/nixpkgs/commit/bcb34ba8b7a8876f3e665073a6f68d34acb514aa) | `` python311Packages.qcodes-loop: remove ``                                    |
| [`0de321de`](https://github.com/NixOS/nixpkgs/commit/0de321de7253279dd51842f69fde3dd231f7abce) | `` python311Packages.qcodes: disable flaky tests ``                            |
| [`0881edb6`](https://github.com/NixOS/nixpkgs/commit/0881edb66aa4b27e5894898bb2844aee79a5761a) | `` coqPackages.{hydra-battles,gaia-hydras}: 0.6 → 0.9 ``                       |
| [`36878436`](https://github.com/NixOS/nixpkgs/commit/36878436756a147c04f1ab11cdfc560e9523bf19) | `` coqPackages.gaia: 1.15 → 1.17 ``                                            |
| [`6755e476`](https://github.com/NixOS/nixpkgs/commit/6755e47637aef2302102457eaa6e0223cf9972a1) | `` mold: 2.3.3 -> 2.4.0 ``                                                     |
| [`dbe4453f`](https://github.com/NixOS/nixpkgs/commit/dbe4453f436f00977170ae7d1b5f633a49d6686d) | `` python310Packages.cloup: 3.0.2 -> 3.0.3 ``                                  |
| [`936af716`](https://github.com/NixOS/nixpkgs/commit/936af716350f50a2b02380f49c4922bf4c43a105) | `` okteto: 2.22.0 -> 2.22.3 ``                                                 |
| [`776c4279`](https://github.com/NixOS/nixpkgs/commit/776c4279109d1d1e5e7fecac6be3ffbddd0e2e6d) | `` python311Packages.qcodes: 0.41.1 -> 0.42.0 ``                               |
| [`54a8f13f`](https://github.com/NixOS/nixpkgs/commit/54a8f13f93858764fb89cf3f9ee02674557bf11f) | `` avr-sim: init at 2.8 ``                                                     |
| [`9b58faad`](https://github.com/NixOS/nixpkgs/commit/9b58faad99f8418baea31a6a1293c7f9c21b1d86) | `` nixosTests.jitsi-meet: test `cfg.caddy.enable` ``                           |
| [`9a821ebe`](https://github.com/NixOS/nixpkgs/commit/9a821ebe0fcd5a74e1aa4286d43ace78b30be909) | `` nixos/jitsi-meet: fix `cfg.caddy.enable` ``                                 |
| [`6c455651`](https://github.com/NixOS/nixpkgs/commit/6c4556515f1669ea6e9589feb61c149f36d98628) | `` conserve: 23.9.0 -> 23.11.0 ``                                              |
| [`4585058f`](https://github.com/NixOS/nixpkgs/commit/4585058fc614fcf05f13016ef2a2c00434fad89b) | `` spectrwm: unstable-2023-05-07 -> 3.5.1 ``                                   |
| [`91666651`](https://github.com/NixOS/nixpkgs/commit/916666515a9418eafb503f0092c1bcf5fb855f56) | `` maintainers: christianharke -> rake5k ``                                    |
| [`e8fb6417`](https://github.com/NixOS/nixpkgs/commit/e8fb64175f40d95438edcd2bdac6c4463f9268a8) | `` publii: 0.43.1 -> 0.44.1 ``                                                 |
| [`da49e141`](https://github.com/NixOS/nixpkgs/commit/da49e141e62ed3c1c44ab3426658f4ff999b254b) | `` eza: 0.16.1 -> 0.16.2 ``                                                    |
| [`6e1ae782`](https://github.com/NixOS/nixpkgs/commit/6e1ae782c2fcb6d03dcd52ac7d345e3177f6347a) | `` fortune-kind: 0.1.10 -> 0.1.11 ``                                           |
| [`556712bb`](https://github.com/NixOS/nixpkgs/commit/556712bb7c057797d5b83d6349ec443084421877) | `` acgtk: 1.5.4 → 2.0.0 ``                                                     |
| [`147eabb0`](https://github.com/NixOS/nixpkgs/commit/147eabb0f47b6cf6be50ae5a1ffb021f33088526) | `` ocamlPackages.readline: init at 0.1 ``                                      |
| [`c3055100`](https://github.com/NixOS/nixpkgs/commit/c305510073b8a3b843dd7e35969c59aa18369a3c) | `` anki-sync-server: init at 2.1.66 ``                                         |
| [`46f83cdd`](https://github.com/NixOS/nixpkgs/commit/46f83cdd85f4624dc632b21c101beb9b5e8225d4) | `` mmctl: 7.10.5 -> 9.2.2 (#269709) ``                                         |
| [`c0fad37a`](https://github.com/NixOS/nixpkgs/commit/c0fad37a70cce3f219614fdf4e41fed42dfa19bc) | `` sing-box: 1.6.7 -> 1.7.0 ``                                                 |
| [`0bfbf285`](https://github.com/NixOS/nixpkgs/commit/0bfbf2857781aa9ccd9f52e553789ad850e4536e) | `` python311Packages.aiorecollect: 2023.09.0 -> 2023.11.0 ``                   |
| [`8c734937`](https://github.com/NixOS/nixpkgs/commit/8c734937d6473d4e707c5c96c36e3d91009d2e3d) | `` nixos/sourcehut: fix eval ``                                                |
| [`85cba397`](https://github.com/NixOS/nixpkgs/commit/85cba39704aa90dfa6d33bd05e57996d112165f4) | `` rtx: change username of repo owner ``                                       |
| [`73df03d0`](https://github.com/NixOS/nixpkgs/commit/73df03d0c43559a4131ec95da0d92c6550b05237) | `` clear: set platforms ``                                                     |
| [`27e8db2b`](https://github.com/NixOS/nixpkgs/commit/27e8db2bcfd32a9bcc24a68347cd493a4b3f4e7d) | `` bilibili: update meta info ``                                               |
| [`e86c08bf`](https://github.com/NixOS/nixpkgs/commit/e86c08bf2065ab9eb8bc329e0fca3098c31e8ded) | `` syft: 0.97.1 -> 0.98.0 ``                                                   |
| [`15185e53`](https://github.com/NixOS/nixpkgs/commit/15185e5362c194dc44db1ba5545ae98dfbdd8f30) | `` python311Packages.peft: 0.6.0 -> 0.6.2 ``                                   |
| [`51378601`](https://github.com/NixOS/nixpkgs/commit/51378601be3c9da32a51c5f3336bb90bf446f604) | `` spicetify-cli: 2.27.1 -> 2.27.2 ``                                          |
| [`abbd12a2`](https://github.com/NixOS/nixpkgs/commit/abbd12a26eac18d0a471adc1313b1742cde4ce86) | `` python310Packages.pinocchio: fix build on x86_64-darwin ``                  |
| [`c7eca14f`](https://github.com/NixOS/nixpkgs/commit/c7eca14f84da53d15d25cb1019c0a5cb5a706efc) | `` python311Packages.optimum: 1.14.0 -> 1.14.1 ``                              |
| [`52f4aaf4`](https://github.com/NixOS/nixpkgs/commit/52f4aaf4170b592222901768667ae3e3dd66989b) | `` python311Packages.pyairvisual: 2023.08.0 -> 2023.11.0 ``                    |
| [`517d5ab0`](https://github.com/NixOS/nixpkgs/commit/517d5ab0b5646a36a971503b5c638aa7106d8ad5) | `` chia: drop ``                                                               |
| [`e79e4fa3`](https://github.com/NixOS/nixpkgs/commit/e79e4fa3f2d85925f18c3c8ed876d3db575f21a5) | `` python311Packages.zamg: modernize ``                                        |
| [`4d568d2f`](https://github.com/NixOS/nixpkgs/commit/4d568d2fa75612207b7207528789a149f8994841) | `` python311Packages.zamg: 0.3.1 -> 0.3.3 ``                                   |
| [`e1906b8e`](https://github.com/NixOS/nixpkgs/commit/e1906b8e81164d8debd99c0c2c8235004b9e5c56) | `` python311Packages.pyopenuv: 2023.08.0 -> 2023.11.0 ``                       |
| [`e8120b95`](https://github.com/NixOS/nixpkgs/commit/e8120b95c5528bf15c485b692976c7a3b07e3421) | `` streamlink: 6.4.1 -> 6.4.2 ``                                               |
| [`463ec8a2`](https://github.com/NixOS/nixpkgs/commit/463ec8a215dc4f7cdaa2132ba33d68e9ab044105) | `` pastebinit: change upstream to maintained fork and add manpage ``           |
| [`50f8513e`](https://github.com/NixOS/nixpkgs/commit/50f8513e1f2bd45154b120a2ac9fc121dd66245d) | `` vscode-extensions.devsense.phptools-vscode: 1.36.13428 -> 1.41.14332 ``     |
| [`898592c6`](https://github.com/NixOS/nixpkgs/commit/898592c6937fd099e4943c96b990f96be98cbd89) | `` vscode-extensions.devsense.profiler-php-vscode: 1.36.13428 -> 1.41.14332 `` |
| [`3702d074`](https://github.com/NixOS/nixpkgs/commit/3702d0740e0a9978216396adaaf86126f8e2b6ee) | `` libcotp: 2.0.2 -> 2.1.0 ``                                                  |
| [`7f1a7617`](https://github.com/NixOS/nixpkgs/commit/7f1a76173f5276fc44b6e3aaca2041eb49ddbec2) | `` vscode-extensions.devsense.composer-php-vscode: 1.36.13428 -> 1.41.14332 `` |
| [`0295c486`](https://github.com/NixOS/nixpkgs/commit/0295c486fa854220ee2bc019bb03e389483ea941) | `` brave: 1.60.118 -> 1.60.125 ``                                              |
| [`3ec2a5b1`](https://github.com/NixOS/nixpkgs/commit/3ec2a5b1af167e25dca9b2411e1cf74d804e7d6d) | `` aardvark-dns: 1.8.0 -> 1.9.0 ``                                             |
| [`3ee77f20`](https://github.com/NixOS/nixpkgs/commit/3ee77f209e7ccbebb87f4e8a9c40fba02b4f2178) | `` checkov: 3.1.18 -> 3.1.19 ``                                                |
| [`2c01cd06`](https://github.com/NixOS/nixpkgs/commit/2c01cd06afc2e327343b047e27e172ba488d98f8) | `` dune_3: 3.12.0 -> 3.12.1 ``                                                 |
| [`50188c47`](https://github.com/NixOS/nixpkgs/commit/50188c47ae98c9f2c5c25642fcc9b40fd559a7a2) | `` python311Packages.keyrings-google-artifactregistry-auth: 1.1.1 -> 1.1.2 ``  |
| [`0e1c8f57`](https://github.com/NixOS/nixpkgs/commit/0e1c8f57a20c269ff65914b2e0c106ada8a617c1) | `` python311Packages.keyrings-passwordstore: mark broken ``                    |
| [`897387bb`](https://github.com/NixOS/nixpkgs/commit/897387bb273012c21ea1f0b1e17ef8e29e602dff) | `` yosys-synlig: 2023-10-26 -> 2023-11-28 ``                                   |
| [`409e9d1a`](https://github.com/NixOS/nixpkgs/commit/409e9d1a3097bc7199e48f6d696851a279eaf94d) | `` surelog: 1.76 -> 1.80 ``                                                    |
| [`39dd77fd`](https://github.com/NixOS/nixpkgs/commit/39dd77fde893e04cafa43c0ac2299e9e6940c9c9) | `` uhdm: 1.77 -> 1.80 ``                                                       |
| [`115fc8c3`](https://github.com/NixOS/nixpkgs/commit/115fc8c3c6619376fc55335d934c98ea9e540e07) | `` carapace: 0.28.3 -> 0.28.4 ``                                               |
| [`627e5e6a`](https://github.com/NixOS/nixpkgs/commit/627e5e6a72aea50cf5c3376ca18fcf8dc19e5cea) | `` dasel: 2.4.1 -> 2.5.0 ``                                                    |
| [`38e57839`](https://github.com/NixOS/nixpkgs/commit/38e57839ef6590f512dda9af917423c435a19bb0) | `` maintainers: update mmlb email ``                                           |
| [`5057a89f`](https://github.com/NixOS/nixpkgs/commit/5057a89f572689f1b3a70bc8b909aa697aac738c) | `` rl-2311: Minor fixes ``                                                     |
| [`b2a18a7c`](https://github.com/NixOS/nixpkgs/commit/b2a18a7caa184810e161ecf77cd5fbfeabd4b7a2) | `` opentofu: add nickcao to maintainers ``                                     |
| [`63cff108`](https://github.com/NixOS/nixpkgs/commit/63cff10811ae8e9645b82db76a48644e0c3042f9) | `` linuxKernel.kernels.linux_lqx: 6.6.2-lqx1 -> 6.6.3-lqx1 ``                  |
| [`4b7ef895`](https://github.com/NixOS/nixpkgs/commit/4b7ef895e4306c37d3f1038a12eceef5fe67aaac) | `` opentofu: 1.6.0-alpha5 -> 1.6.0-beta1 ``                                    |
| [`04220ed6`](https://github.com/NixOS/nixpkgs/commit/04220ed6763637e5899980f98d5c8424b1079353) | `` Release NixOS 23.11 ``                                                      |
| [`b460856e`](https://github.com/NixOS/nixpkgs/commit/b460856efa7e4b2f7297c98c778658a766237286) | `` 23.11 release notes: editing updates (#270967) ``                           |
| [`778c8225`](https://github.com/NixOS/nixpkgs/commit/778c8225bafe78e83a942132ee5c21a056679216) | `` vulkan-cts: 1.3.7.0 -> 1.3.7.2 ``                                           |
| [`475ec064`](https://github.com/NixOS/nixpkgs/commit/475ec06484abaee700e637a1634b2b44fa357bee) | `` pastel: add meta.mainProgram ``                                             |