### PR TITLE
chore(flake/nixpkgs): `3934dbde` -> `eae82ed7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1701368325,
-        "narHash": "sha256-3OqZyi2EdopJxpxwrySPyCTuCvfBY4oXTLVgQ4B6qDg=",
+        "lastModified": 1704015712,
+        "narHash": "sha256-GrsuUCEH5T629Py4jt6tsIzu9nEL/fD2Qt986ib13WI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3934dbde4f4a0e266825348bc4ad1bdd00a8d6a3",
+        "rev": "eae82ed71467a19374437376fbb7f5e3ad486aeb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                         |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`f63f3a08`](https://github.com/NixOS/nixpkgs/commit/f63f3a08f3b3a22c63f1fafe8265eb9c6a1e65f8) | `` qspeakers: init at 1.6.9 ``                                                  |
| [`0ae1ed41`](https://github.com/NixOS/nixpkgs/commit/0ae1ed4108111d8bfe65aa37b572c050d350603c) | `` xfce.thunar: 4.18.9 -> 4.18.10 ``                                            |
| [`1c51b3ca`](https://github.com/NixOS/nixpkgs/commit/1c51b3ca3ea0b9a99607b3a12ea6e54f32e2a770) | `` python311Packages.django-reversion: 5.0.9 -> 5.0.10 ``                       |
| [`991ee472`](https://github.com/NixOS/nixpkgs/commit/991ee472df16e932676584362087539451f70781) | `` python311Packages.django-reversion: switch to pypa build ``                  |
| [`67e82c96`](https://github.com/NixOS/nixpkgs/commit/67e82c96484bfb2fcb5a3f304069c3386695db9f) | `` python311Packages.scikit-build-core: 0.5.1 -> 0.7.0 ``                       |
| [`cba7a53a`](https://github.com/NixOS/nixpkgs/commit/cba7a53a3d8c8e9175dcd9968cda9be41d11e7a8) | `` mcfly-fzf: init at 0.1.2 ``                                                  |
| [`99690d16`](https://github.com/NixOS/nixpkgs/commit/99690d1689fd5f012b83e9372e636d8eeb48bd5f) | `` python311Packages.casbin: 1.33.0 -> 1.34.0 ``                                |
| [`0a128845`](https://github.com/NixOS/nixpkgs/commit/0a128845598c3ecb7f369ffc8ba1ab5d12c67dd6) | `` python311Packages.aioairzone-cloud: 0.3.7 -> 0.3.8 ``                        |
| [`09a5f17e`](https://github.com/NixOS/nixpkgs/commit/09a5f17eec72efd309a3c7a3d5282907522c3e67) | `` lua-wrapper: fix luaPath and luaCpath definitions ``                         |
| [`20172d62`](https://github.com/NixOS/nixpkgs/commit/20172d624ead0be96887bdb4bc66878f9e12d32c) | `` python3Packages.PyLaTeX: init at 1.4.2 ``                                    |
| [`88a82d45`](https://github.com/NixOS/nixpkgs/commit/88a82d455f813078084b10a441e0d7e6601cde63) | `` nix-du: 1.1.1 -> 1.2.0 ``                                                    |
| [`12a8aa5a`](https://github.com/NixOS/nixpkgs/commit/12a8aa5ac8b4d73ba03a171b6beaf2503a00bdcf) | `` python3Packages.openllm-core: fix `optional-dependencies` evaluation ``      |
| [`1977db46`](https://github.com/NixOS/nixpkgs/commit/1977db46630b1e9ba77d96349a392669c9fe88a4) | `` usql: 0.17.0 -> 0.17.2 ``                                                    |
| [`ff69b009`](https://github.com/NixOS/nixpkgs/commit/ff69b009373eec07c4ecdd2cb6adbe49af02dbe9) | `` rat-king-adventure: 1.5.2a -> 1.5.3 ``                                       |
| [`cc0553a6`](https://github.com/NixOS/nixpkgs/commit/cc0553a6388286a917132195eab6e3d9d2c970f3) | `` goxel: 0.12.0 -> 0.13.0 ``                                                   |
| [`7a851d25`](https://github.com/NixOS/nixpkgs/commit/7a851d25937ca85f4f42d8f16024dc74f7f3243e) | `` python3Packages.openllm-client: fix `optional-dependencies` attribute ``     |
| [`8e058b5e`](https://github.com/NixOS/nixpkgs/commit/8e058b5ee7ee70a6114130d131249d5009435df8) | `` turso-cli: 0.87.6 -> 0.87.7 ``                                               |
| [`2765ca15`](https://github.com/NixOS/nixpkgs/commit/2765ca157c232bc79feb10a907ade0d1a018f304) | `` python311Packages.aiounifi: 67 -> 68 ``                                      |
| [`1ac836a2`](https://github.com/NixOS/nixpkgs/commit/1ac836a29599526216763bb12fd3eb7222d13235) | `` terragrunt: 0.54.10 -> 0.54.12 ``                                            |
| [`da90576a`](https://github.com/NixOS/nixpkgs/commit/da90576aace1c178811ec136607e595d4f39dbae) | `` nixos/lxd-agent: fix evaluation regression caused by nixos/nixpkgs#271326 `` |
| [`5b2eefcc`](https://github.com/NixOS/nixpkgs/commit/5b2eefcc03d53975afae837bf15d94f142b94d71) | `` far2l: 2.4.1 -> 2.5.3 ``                                                     |
| [`4e53e556`](https://github.com/NixOS/nixpkgs/commit/4e53e55619676d7216957af166380ce4f1f0c0d8) | `` python3Packages.flask-security-too: 5.3.2 -> 5.3.3 ``                        |
| [`b13feabb`](https://github.com/NixOS/nixpkgs/commit/b13feabbf1c5ab9ea0923f5a20fd798a0b521469) | `` dkimproxy: fix running (#277729) ``                                          |
| [`c2b88a4f`](https://github.com/NixOS/nixpkgs/commit/c2b88a4fd8e159539039508971d1fe24af070ad1) | `` svd2rust: 0.31.2 -> 0.31.3 ``                                                |
| [`79ed4d99`](https://github.com/NixOS/nixpkgs/commit/79ed4d99dcbf447eaeb03adfd12740681f893f6a) | `` surrealdb-migrations: 1.0.0 -> 1.0.1 ``                                      |
| [`036d7e31`](https://github.com/NixOS/nixpkgs/commit/036d7e31f9d6012fc75afdabf70515a511723991) | `` mtail: build all binaries, enable tests ``                                   |
| [`9267f03e`](https://github.com/NixOS/nixpkgs/commit/9267f03edf26e2d2be1206fd92fe9ff5b128ce9f) | `` sing-box: set meta.mainProgram ``                                            |
| [`cd2a28ef`](https://github.com/NixOS/nixpkgs/commit/cd2a28ef958916db14f68dcc292cc57cdb18388d) | `` python311Packages.pymc: fix hash mismatch ``                                 |
| [`92531c3d`](https://github.com/NixOS/nixpkgs/commit/92531c3d37f2e2c7d5fe6b23d55cd7e90c654849) | `` sequoia-sq: 0.31.0 -> 0.32.0 ``                                              |
| [`9c09d092`](https://github.com/NixOS/nixpkgs/commit/9c09d09241284cfc329d8193af152bf33e16ea6d) | `` revanced-cli: 4.3.0 -> 4.4.0 ``                                              |
| [`6f2b434b`](https://github.com/NixOS/nixpkgs/commit/6f2b434b36e1ee5d76dea8515eca7e24beef4f51) | `` vimPlugins.sniprun: 1.3.9 -> 1.3.10 ``                                       |
| [`20f64b5d`](https://github.com/NixOS/nixpkgs/commit/20f64b5d7752f87ab5dacc3cf9f0759b6945c4e8) | `` agate: 3.3.1 → 3.3.3 ``                                                      |
| [`73a0ea12`](https://github.com/NixOS/nixpkgs/commit/73a0ea127b58a1242926e42ef13d4b63ad7f48a1) | `` wl-mirror: update description to match upstream description ``               |
| [`7f8b667d`](https://github.com/NixOS/nixpkgs/commit/7f8b667d08de49f6336fa171c7b650dedd7a4271) | `` wl-mirror: 0.14.2 -> 0.15.0 ``                                               |
| [`d7e85937`](https://github.com/NixOS/nixpkgs/commit/d7e85937ee89edcb56ad9b713d733adaa9e6b586) | `` octoprint: fix `octoprint-dashboard` alias definition ``                     |
| [`7dc881c7`](https://github.com/NixOS/nixpkgs/commit/7dc881c7551fba2cd91c90b8113f9ab8acb4fe6d) | `` python310Packages.langchainplus-sdk: set alias as langsmith ``               |
| [`c83b707f`](https://github.com/NixOS/nixpkgs/commit/c83b707f2f6795eeeed7d3f24bb21de3a20531a7) | `` minishift: remove ``                                                         |
| [`1e9ffe17`](https://github.com/NixOS/nixpkgs/commit/1e9ffe1725055605e1759714ffcae64d2a5b83ce) | `` sqls: 0.2.27 -> 0.2.28 ``                                                    |
| [`1878ed25`](https://github.com/NixOS/nixpkgs/commit/1878ed25eb2aa90e652854dc85b706d545c43f49) | `` ov: 0.32.1 -> 0.33.0 ``                                                      |
| [`09c33746`](https://github.com/NixOS/nixpkgs/commit/09c337469128b8f8897b9a0ca1cfc1770cbbb29c) | `` sqls: 0.2.22 -> 0.2.27 ``                                                    |
| [`c6aef2e8`](https://github.com/NixOS/nixpkgs/commit/c6aef2e8b7948b2b13b3b931a1ee7ff90b5cfb8a) | `` python311Packages.skodaconnect: update disabled ``                           |
| [`47d6b219`](https://github.com/NixOS/nixpkgs/commit/47d6b21930a651faf1fd9f217423281c5332dc9f) | `` flake.nix: Add caveats ``                                                    |
| [`834f8f42`](https://github.com/NixOS/nixpkgs/commit/834f8f42c220a1dcbbbc8b848e7e9b98f5a9dc41) | `` gtree: 1.10.4 -> 1.10.7 ``                                                   |
| [`5a59fa5f`](https://github.com/NixOS/nixpkgs/commit/5a59fa5f03e3bc9e537636e809e781f66cb70bf1) | `` python310Packages.textual-dev: 1.2.1 -> 1.3.0 ``                             |
| [`6d2655d7`](https://github.com/NixOS/nixpkgs/commit/6d2655d7d209a31289c20892388dc3867496aef1) | `` python311Packages.zope-exceptions: 4.6 -> 5.0.1 ``                           |
| [`16b879f3`](https://github.com/NixOS/nixpkgs/commit/16b879f3ef6ff1ecfb1c1d23e3072f8c1a9e39e9) | `` python311Packages.zope-exceptions: refactor ``                               |
| [`06afa106`](https://github.com/NixOS/nixpkgs/commit/06afa1060dcb6aa5a5808e3211e932c1783e1aa1) | `` python311Packages.zope-exceptions: rename from zope_exceptions ``            |
| [`d99161d1`](https://github.com/NixOS/nixpkgs/commit/d99161d19121f75ce0ad568803693a9599dd5d04) | `` plymouth: 23.356.9 -> 23.360.11 ``                                           |
| [`b60e4a8d`](https://github.com/NixOS/nixpkgs/commit/b60e4a8df1be97a74078d81d8540ec9973b1c444) | `` python311Packages.pycrdt: 0.7.2 -> 0.8.2 ``                                  |
| [`d054a1c2`](https://github.com/NixOS/nixpkgs/commit/d054a1c2e981b07c0862cdaa884f22128ea80682) | `` python311Packages.thermobeacon-ble: refactor ``                              |
| [`ad05fc68`](https://github.com/NixOS/nixpkgs/commit/ad05fc68c0dac1306ec95d030204dd9e442a24f9) | `` python311Packages.thermobeacon-ble: 0.6.0 -> 0.6.2 ``                        |
| [`f6ac391a`](https://github.com/NixOS/nixpkgs/commit/f6ac391a8be1a80bf4fb98a1a56bf931b664f677) | `` python311Packages.velbus-aio: 2023.11.0 -> 2023.12.0 ``                      |
| [`806f73ae`](https://github.com/NixOS/nixpkgs/commit/806f73ae7d6881f2dcac477e78f8c0d360e36699) | `` qovery-cli: 0.77.0 -> 0.79.0 ``                                              |
| [`889213c7`](https://github.com/NixOS/nixpkgs/commit/889213c7cd89ebd2b233506f3d742541f0a6e7f1) | `` widevine-cdm: 4.10.2557.0 -> 4.10.2710.0 ``                                  |
| [`890d5d2b`](https://github.com/NixOS/nixpkgs/commit/890d5d2b2a2cc2e7b026ff4882095874c29d0f6e) | `` thepeg: 2.2.3 -> 2.3.0 ``                                                    |
| [`98d8b599`](https://github.com/NixOS/nixpkgs/commit/98d8b599cd111a828c29b754a7a7570238e817bc) | `` sfeed: 1.9 -> 2.0 ``                                                         |
| [`97825d37`](https://github.com/NixOS/nixpkgs/commit/97825d37abf46a9ba9af74e4e9a8798fd6c8b207) | `` python311Packages.tplink-omada-client: 1.3.6 -> 1.3.7 ``                     |
| [`d7b7c399`](https://github.com/NixOS/nixpkgs/commit/d7b7c399cd93cae44d7aaed1a24134562dc91532) | `` python311Packages.pycrdt-websocket: 0.12.5 -> 0.12.6 ``                      |
| [`7fc1ba51`](https://github.com/NixOS/nixpkgs/commit/7fc1ba51589476315f8cec905dd0ca4efe6d2cb6) | `` python311Packages.roombapy: 1.6.9 -> 1.6.10 ``                               |
| [`5a54c339`](https://github.com/NixOS/nixpkgs/commit/5a54c339b5ef0413f4b330b7304f9e361852a916) | `` python311Packages.plexapi: 4.15.6 -> 4.15.7 ``                               |
| [`2ecaa715`](https://github.com/NixOS/nixpkgs/commit/2ecaa715f36015cf897e24eea14b02da2a6bff0f) | `` htmx-lsp: init at 0.1.0 ``                                                   |
| [`a7133106`](https://github.com/NixOS/nixpkgs/commit/a71331063266bc65b48e61793d252e485efa1381) | `` twm: 0.8.1 -> 0.8.2 ``                                                       |
| [`52c26b44`](https://github.com/NixOS/nixpkgs/commit/52c26b4473feed01612ccc2cd24c02c7f372160a) | `` vscode-extensions.dracula-theme.theme-dracula: 2.24.2 -> 2.24.3 ``           |
| [`a13a9271`](https://github.com/NixOS/nixpkgs/commit/a13a92713e28e2c641f5cb44df9de5e36b3152b6) | `` obs-studio-plugins.obs-move-transition: 2.9.6 -> 2.9.8 ``                    |
| [`65e75d69`](https://github.com/NixOS/nixpkgs/commit/65e75d699ce56e0f8a125d784885305e4c1eddce) | `` vscode-extensions.serayuzgur.crates: 0.6.0 -> 0.6.5 ``                       |
| [`7322f0f2`](https://github.com/NixOS/nixpkgs/commit/7322f0f2adf88d0cc24b2b4af379488978934527) | `` just: 1.20.0 -> 1.21.0 ``                                                    |
| [`068e9d43`](https://github.com/NixOS/nixpkgs/commit/068e9d43248e90d69f292b8afd752b0a99e428ea) | `` sing-box: 1.7.6 -> 1.7.7 ``                                                  |
| [`07964df9`](https://github.com/NixOS/nixpkgs/commit/07964df9f55546110cc02f6a648a2ad0dfc84fd5) | `` python311Packages.rdkit: 2023.09.1 -> 2023.09.3 ``                           |
| [`4fa311aa`](https://github.com/NixOS/nixpkgs/commit/4fa311aa43cc527d5a407da25e0bde2be7e41551) | `` coordgenlibs: refactor ``                                                    |
| [`1881026b`](https://github.com/NixOS/nixpkgs/commit/1881026b3d5e4979fc3b791ec905701b7ab95629) | `` coordgenlibs: enable tests ``                                                |
| [`30c18812`](https://github.com/NixOS/nixpkgs/commit/30c188124d90e2b323df3245af6c7de673be3c0a) | `` coordgenlibs: fix build with clang ``                                        |
| [`13da729f`](https://github.com/NixOS/nixpkgs/commit/13da729f6ed36982fb2d97bed6d7c3084f6816b7) | `` yt-dlp: 2023.11.16 -> 2023.12.30 ``                                          |
| [`90718307`](https://github.com/NixOS/nixpkgs/commit/90718307e88117d6cce03e6f47cec2ff9a3a8f72) | `` tdlib: 1.8.22 -> 1.8.23 ``                                                   |
| [`a1422a7f`](https://github.com/NixOS/nixpkgs/commit/a1422a7f8f12b68e307b92b7daa254f412e9ff96) | `` build-support/go: fix eval of `vendorSha256` accesses ``                     |
| [`32f27641`](https://github.com/NixOS/nixpkgs/commit/32f27641a0ffc60ef734b2ea338fe5eb56cd6641) | `` buildbot-worker: mark broken on darwin ``                                    |
| [`2b0e5f12`](https://github.com/NixOS/nixpkgs/commit/2b0e5f1244169655c4613e63d4e812b4e5ab0353) | `` buildbot: sqlalchemy: 1.4.49 -> 1.4.50 ``                                    |
| [`41e3e7ef`](https://github.com/NixOS/nixpkgs/commit/41e3e7ef30819ecad84389c40827f62c7b7acbb6) | `` buildbot: 3.10.0 -> 3.10.1 ``                                                |
| [`4011dd66`](https://github.com/NixOS/nixpkgs/commit/4011dd666b312834166426bf9073423efa7d82fa) | `` talosctl: 1.6.0 -> 1.6.1 ``                                                  |
| [`594c284f`](https://github.com/NixOS/nixpkgs/commit/594c284fa7ec4539b5defd432951dd7dcc5f1e75) | `` home-assistant-custom-lovelace-modules.light-entity-card: 6.1.0 -> 6.1.1 ``  |
| [`ec390d5e`](https://github.com/NixOS/nixpkgs/commit/ec390d5e514d82c00dad1205f33293a8fa0e35ec) | `` supabase-cli: 1.129.0 -> 1.129.1 ``                                          |
| [`750935f7`](https://github.com/NixOS/nixpkgs/commit/750935f7f0df9b21d86f716bc2afa80d10161a5c) | `` stgit: 2.4.1 -> 2.4.2 ``                                                     |
| [`5a500574`](https://github.com/NixOS/nixpkgs/commit/5a500574ebf4747912e733435f39e4a6ffed2ea0) | `` luaPackages.toml-edit: 0.1.4 -> 0.1.5 ``                                     |
| [`de9dba61`](https://github.com/NixOS/nixpkgs/commit/de9dba61f9b08748bb4388963d6477cfb11d41d1) | `` yubihsm-connector: fix cross compilation ``                                  |
| [`9d530ca6`](https://github.com/NixOS/nixpkgs/commit/9d530ca6fe52d3beb2cfffb2a45b3074f901c90f) | `` micro: fix cross compilation ``                                              |
| [`b5adf1b6`](https://github.com/NixOS/nixpkgs/commit/b5adf1b6165b8da9d6a5200b7f2a7e85cea612b6) | `` traefik: fix cross compilation ``                                            |
| [`e9cdd5fa`](https://github.com/NixOS/nixpkgs/commit/e9cdd5fae80497c1fefaffff872416822566e04c) | `` julia.withPackages: handle non-archive artifacts (fixes #277410) ``          |
| [`84e76aef`](https://github.com/NixOS/nixpkgs/commit/84e76aef99911253445faf69f9d1682e65c392b8) | `` snappymail: 2.31.0 -> 2.32.0 ``                                              |
| [`04df6aa7`](https://github.com/NixOS/nixpkgs/commit/04df6aa7bad237aeeb69f603e1f4ec1a2c28a4da) | `` organicmaps: 2023.11.17-17 -> 2023.12.20-4 ``                                |
| [`2ca9b484`](https://github.com/NixOS/nixpkgs/commit/2ca9b484dd3ccfedb1f938cf2396fa0e1fe8aeda) | `` denaro: 2023.9.2 -> 2023.11.0 ``                                             |
| [`aea1f78a`](https://github.com/NixOS/nixpkgs/commit/aea1f78ac32b247f45210c7394ede6c0dd106205) | `` python311Packages.opensensemap-api: 0.3.1 -> 0.3.2 ``                        |
| [`a3048a66`](https://github.com/NixOS/nixpkgs/commit/a3048a660d85b28924c5681abb59281d534ff391) | `` sd-local: 1.0.50 -> 1.0.51 ``                                                |
| [`4d96a0f9`](https://github.com/NixOS/nixpkgs/commit/4d96a0f96f69eeb26e058417441f93638c2a9e9a) | `` envfs: 1.0.2 -> 1.0.3 ``                                                     |
| [`a60dcc7f`](https://github.com/NixOS/nixpkgs/commit/a60dcc7fc14c658e16fb306800f7157682dc0cbe) | `` jellyfin-ffmpeg: fix `tests` eval ``                                         |
| [`62455ade`](https://github.com/NixOS/nixpkgs/commit/62455ade3cb6fcc9635ab8e7591a12f1c0d88f08) | `` qgis-ltr: 3.28.13 -> 3.28.14 ``                                              |
| [`d32abf7f`](https://github.com/NixOS/nixpkgs/commit/d32abf7f983ac73cdc30b7c8540f94ad2f658814) | `` qgis: 3.34.1 -> 3.34.2 ``                                                    |
| [`39adbc54`](https://github.com/NixOS/nixpkgs/commit/39adbc54560e1f0072fc84d5228a5b6063ba6300) | `` devpod: fix `tests` eval ``                                                  |
| [`02ebf149`](https://github.com/NixOS/nixpkgs/commit/02ebf149d53e5ac815e3dd4f668a088faa671dd3) | `` nixos/release-notes: more details about Nextcloud options rename ``          |
| [`d3fdf4df`](https://github.com/NixOS/nixpkgs/commit/d3fdf4df0ac2456fa04842b66e7f7b418b0614eb) | `` findup: fix `tests` eval ``                                                  |
| [`ce228ed6`](https://github.com/NixOS/nixpkgs/commit/ce228ed6bd232d33d35f5a1a8595c6b96c67ecc9) | `` fakeroot: fix `tests` eval ``                                                |
| [`25f25d78`](https://github.com/NixOS/nixpkgs/commit/25f25d78bfd668e32679f7c7dca5e8e964d598d9) | `` ryujinx: 1.1.1100 -> 1.1.1102 ``                                             |
| [`e8e5c07a`](https://github.com/NixOS/nixpkgs/commit/e8e5c07ad0b7ba7e068cf3de81823cb0fe238c3c) | `` nixos/matrix-sliding-sync: rename, init dendrite ``                          |
| [`74ee8380`](https://github.com/NixOS/nixpkgs/commit/74ee8380c002d06807942a45ef1971ce951c51c3) | `` rust-analyzer-unwrapped: 2023-11-13 -> 2023-12-25 ``                         |
| [`bb90caa7`](https://github.com/NixOS/nixpkgs/commit/bb90caa75c509a1d26f8f52fc3678de9552e9fd3) | `` rure: 0.2.2 -> 0.2.2 ``                                                      |
| [`bae5e651`](https://github.com/NixOS/nixpkgs/commit/bae5e6516269cc804974ef2d5f494d46f7a012c1) | `` nixos/nextcloud: fix nginx routing to store and nix apps ``                  |
| [`bf3b6842`](https://github.com/NixOS/nixpkgs/commit/bf3b68426906c08b10f4e6f99729b7d2214a9d15) | `` tigervnc: fix `tests` eval ``                                                |
| [`1038d49c`](https://github.com/NixOS/nixpkgs/commit/1038d49c331c07cb0750c23f1f32dc15e3d49b68) | `` netbootxyz-efi: 2.0.60 -> 2.0.75 ``                                          |
| [`ea34b38d`](https://github.com/NixOS/nixpkgs/commit/ea34b38d74f1aca48d0baa99c40bfd0378c056b6) | `` jasmin-compiler: 2023.06.1 → 2023.06.2 ``                                    |
| [`a3ec62e6`](https://github.com/NixOS/nixpkgs/commit/a3ec62e683c5236889a5b2856bf3ad5219835041) | `` python3Packages.monitorcontrol: init at 3.1.0 ``                             |