### PR TITLE
chore(flake/nixpkgs): `eae82ed7` -> `632751bf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1704015712,
-        "narHash": "sha256-GrsuUCEH5T629Py4jt6tsIzu9nEL/fD2Qt986ib13WI=",
+        "lastModified": 1706672657,
+        "narHash": "sha256-API05c0SDZrmzz1wpqt/K3iCwlaOqDeDfZGp0YGQnek=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "eae82ed71467a19374437376fbb7f5e3ad486aeb",
+        "rev": "632751bf0ceeefc74af7a9d2335ea923ad9c831a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                            |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
| [`b1c8402d`](https://github.com/NixOS/nixpkgs/commit/b1c8402d71da3a61035b05d6f60b423e74a38b74) | `` vscode-extensions.serayuzgur.crates: 0.6.5 -> 0.6.6 ``                                          |
| [`cd5a7a3a`](https://github.com/NixOS/nixpkgs/commit/cd5a7a3ac9594456c63150e5d2fb43f7f4dd3073) | `` python311Packages.types-pyopenssl: 23.3.0.20240106 -> 24.0.0.20240130 ``                        |
| [`241fca1e`](https://github.com/NixOS/nixpkgs/commit/241fca1ecee7a023be5aa1ee77c1df11319cd49d) | `` dex-oidc: 2.37.0 -> 2.38.0 (#283991) ``                                                         |
| [`5b5e6f99`](https://github.com/NixOS/nixpkgs/commit/5b5e6f990070ec0c5c343ff9160554866ecd23c2) | `` bcachefs-tools: fix fuseSupport option ``                                                       |
| [`ca7640c3`](https://github.com/NixOS/nixpkgs/commit/ca7640c30e53d0a8784cb7c2ffac16a4d29d5acb) | `` git-cinnabar: 0.6.2 -> 0.6.3 ``                                                                 |
| [`f7b31dd5`](https://github.com/NixOS/nixpkgs/commit/f7b31dd5a425a6d98b1906b7d63b615ad8237b55) | `` docfd: init at 2.1.0 ``                                                                         |
| [`19b3ab3f`](https://github.com/NixOS/nixpkgs/commit/19b3ab3fe467bc1ec5cb06f7e5ca4b6bcdea548b) | `` packagekit: use test_nop backend by default ``                                                  |
| [`899edf6b`](https://github.com/NixOS/nixpkgs/commit/899edf6b4dd0db4c78f71acbccd29eeed9e2fc01) | `` yubikey-manager: 5.2.1 -> 5.3.0 ``                                                              |
| [`79a02c82`](https://github.com/NixOS/nixpkgs/commit/79a02c82ec8b101749fd1d46176917d42b068a2c) | `` qovery-cli: 0.81.1 -> 0.82.0 ``                                                                 |
| [`a54b213d`](https://github.com/NixOS/nixpkgs/commit/a54b213de0700f770116440235207cd6556130bf) | `` trufflehog: 3.65.0 -> 3.66.1 ``                                                                 |
| [`a180dfb0`](https://github.com/NixOS/nixpkgs/commit/a180dfb061db015477fcaadd2deacff7ab7c0a07) | `` python311Packages.rokuecp: 0.18.2 -> 0.19.0 ``                                                  |
| [`5204fe15`](https://github.com/NixOS/nixpkgs/commit/5204fe158175a1af3d197df1f0e5a695f6df1761) | `` python311Packages.requests-pkcs12: 1.22 -> 1.24 ``                                              |
| [`4449cd9f`](https://github.com/NixOS/nixpkgs/commit/4449cd9f0c3bb72511a6d92e95b737cbb9b75e77) | `` python311Packages.reconplogger: 4.13.0 -> 4.14.0 ``                                             |
| [`d32813db`](https://github.com/NixOS/nixpkgs/commit/d32813db52afbdd5b7de79dd25936b30aebd161f) | `` python311Packages.regenmaschine: 2023.12.0 -> 2024.01.0 ``                                      |
| [`951aac17`](https://github.com/NixOS/nixpkgs/commit/951aac17f75bb1008bd567b874b865453d4b9701) | `` checkov: 3.2.1 -> 3.2.2 ``                                                                      |
| [`4ea60f6a`](https://github.com/NixOS/nixpkgs/commit/4ea60f6ae42960ade3456c80bbd5f4ac7d9ea774) | `` python311Packages.neo4j: 5.16.0 -> 5.17.0 ``                                                    |
| [`e62b24c8`](https://github.com/NixOS/nixpkgs/commit/e62b24c8dd4dfcc174598c5d6f6c7b47ee11f9b2) | `` python311Packages.ldfparser: 0.21.0 -> 0.22.0 ``                                                |
| [`766300ba`](https://github.com/NixOS/nixpkgs/commit/766300ba3d423717a98c49933fa290ba8d2d3ce0) | `` python311Packages.cyclonedx-python-lib: 6.4.0 -> 6.4.1 ``                                       |
| [`8cbeee9a`](https://github.com/NixOS/nixpkgs/commit/8cbeee9a796f8b3b6ae716499678026151dd8c31) | `` python311Packages.boto3-stubs: 1.34.29 -> 1.34.30 ``                                            |
| [`84bbcf7f`](https://github.com/NixOS/nixpkgs/commit/84bbcf7f6996a4a76962990f5ab445c6c347d571) | `` python311Packages.botocore-stubs: 1.34.29 -> 1.34.30 ``                                         |
| [`36a00242`](https://github.com/NixOS/nixpkgs/commit/36a00242a108f69fad600d599cac43c65db2baa6) | `` python311Packages.dissect-target: refactor ``                                                   |
| [`c3d57efe`](https://github.com/NixOS/nixpkgs/commit/c3d57efe3b424b9b84811c6c92a2745c43f435cb) | `` python311Packages.dissect-cstruct: update disabled ``                                           |
| [`d1d8df0b`](https://github.com/NixOS/nixpkgs/commit/d1d8df0bd9ca006408cf4403fce6f1c9cbe0827e) | `` nextpnr: 0.6 -> 0.7 ``                                                                          |
| [`d825ebfb`](https://github.com/NixOS/nixpkgs/commit/d825ebfbf694703ce2deabf388bd3a65519dab58) | `` nextpnr: enable `strictDeps` ``                                                                 |
| [`23566fe1`](https://github.com/NixOS/nixpkgs/commit/23566fe16df1055c9b26ea7285181973f4bae555) | `` nextpnr: migrate to by-name ``                                                                  |
| [`7dea495d`](https://github.com/NixOS/nixpkgs/commit/7dea495d34f6ae7a82d676bfbb4ec8d90587784c) | `` feat: add test for nonEmptyListOf submodule ``                                                  |
| [`68db973d`](https://github.com/NixOS/nixpkgs/commit/68db973dd84a6e74d2b25a4eeea1a41b58284597) | `` jq-lsp: use upstream go flags ``                                                                |
| [`e00fef32`](https://github.com/NixOS/nixpkgs/commit/e00fef3256c40b5d96a0b42cda5ce6ebf4f1c9a8) | `` jq-lsp: unstable-2023-10-27 -> 0.1.2 ``                                                         |
| [`dad88c02`](https://github.com/NixOS/nixpkgs/commit/dad88c029e2644adfde882f73e9338fd39058a3f) | `` openapi-generator-cli: set mainProgram and use finalAttrs (#284102) ``                          |
| [`ba45aa9f`](https://github.com/NixOS/nixpkgs/commit/ba45aa9f6edfc2efcc3640568ea3914513638a82) | `` sweethome3d: upgrade JDK/JRE ``                                                                 |
| [`6e88f935`](https://github.com/NixOS/nixpkgs/commit/6e88f935da72fb7a11e2c314ce53d453bd52a358) | `` rust-analyzer-unwrapped: 2024-01-22 -> 2024-01-29 ``                                            |
| [`486f3f9d`](https://github.com/NixOS/nixpkgs/commit/486f3f9dfc2670843dc880be2512ca4feb072a9e) | `` mystmd: 1.1.37 -> 1.1.38 ``                                                                     |
| [`120de52a`](https://github.com/NixOS/nixpkgs/commit/120de52a9cbf4d1e0437840327489eb4c03a2dcd) | `` creds: 0.5 -> 0.5.2 ``                                                                          |
| [`e426c6dc`](https://github.com/NixOS/nixpkgs/commit/e426c6dc6a2a1a0661d75b02ef005dbc6da24aa2) | `` db-rest: 6.0.3 -> 6.0.4 ``                                                                      |
| [`0f5e611b`](https://github.com/NixOS/nixpkgs/commit/0f5e611bb679d47ed8534685a9f7013673b3c814) | `` python311Packages.aioopenexchangerates: 0.4.7 -> 0.4.8 ``                                       |
| [`d952b470`](https://github.com/NixOS/nixpkgs/commit/d952b470cbc987b549b0593a439d96e4765247c2) | `` python311Packages.aioftp: 0.22.2 -> 0.22.3 ``                                                   |
| [`efbce80a`](https://github.com/NixOS/nixpkgs/commit/efbce80a36af87c71b506eddef3560e547f805be) | `` discord: 0.0.41 -> 0.0.42 ``                                                                    |
| [`3176d495`](https://github.com/NixOS/nixpkgs/commit/3176d495ff9866aa7dca919dfbdfae3bebd3da96) | `` nixos/plasma5: enable qt stuff ``                                                               |
| [`fc18a474`](https://github.com/NixOS/nixpkgs/commit/fc18a474b4444fc999bff0b5d7f0f8e354a60846) | `` python311Packages.autofaiss: 2.16.0 -> 2.17.0 ``                                                |
| [`acde0f79`](https://github.com/NixOS/nixpkgs/commit/acde0f7966769ab1fd91f48422cd3d9f13b92fe2) | `` nextcloud-client: 3.11.0 -> 3.11.1 ``                                                           |
| [`9188d39c`](https://github.com/NixOS/nixpkgs/commit/9188d39c92920e5c215b827a2efd64b664c2f9db) | `` gcs: 4.8.0 -> 5.20.4, adopt, refactor (#279271) ``                                              |
| [`c9b0753c`](https://github.com/NixOS/nixpkgs/commit/c9b0753c1f5ee6ed2454bdebaed1941864644fb1) | `` wasm-tools: 1.0.55 -> 1.0.57 ``                                                                 |
| [`b8834224`](https://github.com/NixOS/nixpkgs/commit/b88342243996468117173058c0c15a7533394925) | `` deepin.deepin-compressor: 5.12.20 -> 5.12.23 ``                                                 |
| [`89eeaac7`](https://github.com/NixOS/nixpkgs/commit/89eeaac7224cc684396d05fc034a542170857823) | `` bearer: 1.36.0 -> 1.37.0 ``                                                                     |
| [`d422836d`](https://github.com/NixOS/nixpkgs/commit/d422836d725cf3aa70204036b4634dbc6fc3f678) | `` qemu: 8.2.0 -> 8.2.1 ``                                                                         |
| [`74e0cd35`](https://github.com/NixOS/nixpkgs/commit/74e0cd35f6aa9cdd3f576771c1de836eec005072) | `` ncnn: 20231027 -> 20240102 and fix build ``                                                     |
| [`af52a6f3`](https://github.com/NixOS/nixpkgs/commit/af52a6f370ec9aa83cf78d053b3a93e6a52d36c4) | `` prometheus-domain-exporter: 1.22.0 -> 1.23.0 ``                                                 |
| [`6f0525e4`](https://github.com/NixOS/nixpkgs/commit/6f0525e4ab02ab1bbe2f2ade2e1a025aeb744367) | `` guile-chickadee: init at 0.10.0 ``                                                              |
| [`10d7e93c`](https://github.com/NixOS/nixpkgs/commit/10d7e93c7a0590f33ed600b2c3325a37db39d525) | `` osu-lazer: 2024.114.0 -> 2024.130.2 ``                                                          |
| [`9601ae6f`](https://github.com/NixOS/nixpkgs/commit/9601ae6f1c4ce5499babc75ada2c49c6c1226a3c) | `` osu-lazer-bin: 2024.114.0 -> 2024.130.2 ``                                                      |
| [`a6c64fbd`](https://github.com/NixOS/nixpkgs/commit/a6c64fbd3980f14d5338d010d2c30534ac05515c) | `` nixos/strongswan-swanctl: add includes option for secrets (#284742) ``                          |
| [`6d5eef63`](https://github.com/NixOS/nixpkgs/commit/6d5eef63e25b7df1f313b4782057f38c5045cf68) | `` apt: 2.7.9 -> 2.7.10 ``                                                                         |
| [`ae4e6de5`](https://github.com/NixOS/nixpkgs/commit/ae4e6de5b3c6dd077aa90b0e3ac3c0c9bcf45532) | `` chatty: 0.8.0 -> 0.8.1 ``                                                                       |
| [`e770f7fe`](https://github.com/NixOS/nixpkgs/commit/e770f7fe70a870436f4fffc41654f20ae162bd4c) | `` androidStudioPackages.latest: 2023.3.1.5 -> 2023.3.1.7 ``                                       |
| [`3d028d17`](https://github.com/NixOS/nixpkgs/commit/3d028d17c9614032f4988df6af0e27e4b720f6ad) | `` nixos/paperless: update extraConfig to settings in service docs ``                              |
| [`a35ae3a2`](https://github.com/NixOS/nixpkgs/commit/a35ae3a2d05cbf6dc6ac21a6f3267a7df2e13fdb) | `` sweethome3d: fix libGL startup failure ``                                                       |
| [`6719d952`](https://github.com/NixOS/nixpkgs/commit/6719d952b5bee4c7e95e20451cea461f6d0ec34e) | `` fceux: 2.6.6 -> 2.6.6-unstable-2024-01-19 ``                                                    |
| [`6033d9e5`](https://github.com/NixOS/nixpkgs/commit/6033d9e54d97c6b3edaed3f8e004bb9beecc5503) | `` fceux: unpin lua and stdenv ``                                                                  |
| [`03268135`](https://github.com/NixOS/nixpkgs/commit/0326813598f5fa314ca947f0fff7b33d7945eaaa) | `` fceux: 2.6.5 -> 2.6.6 ``                                                                        |
| [`2fd4f1f4`](https://github.com/NixOS/nixpkgs/commit/2fd4f1f45700e181a1dae6c5200ab4643363208b) | `` fceux: 2.6.4 -> 2.6.5 ``                                                                        |
| [`5edaccbf`](https://github.com/NixOS/nixpkgs/commit/5edaccbf212e3f529d5b3bc48b5967a2c55ed03e) | `` fceux: update meta ``                                                                           |
| [`421c1ef1`](https://github.com/NixOS/nixpkgs/commit/421c1ef1217235799e6f6054f4760062b8332081) | `` memento: 1.2.1 -> 1.2.2 ``                                                                      |
| [`dd1e8069`](https://github.com/NixOS/nixpkgs/commit/dd1e8069ce861b13cf48ec0f7166b13eba45b139) | `` CODEOWNERS: add myself to nixos/no-x-libs module ``                                             |
| [`297b4fcc`](https://github.com/NixOS/nixpkgs/commit/297b4fcc5dab36787ed7caeacc7b50077fceb2db) | `` sirius: 7.4.3 -> 7.5.2 ``                                                                       |
| [`c94d63a5`](https://github.com/NixOS/nixpkgs/commit/c94d63a52752188a52f3855e846b0edc4bfa49c8) | `` nixos/utils: fix stack overflow in genJqReplacementSnippet (#284027) ``                         |
| [`dc237cc4`](https://github.com/NixOS/nixpkgs/commit/dc237cc486251f5f021255607736867273945395) | `` octopus: add mpi and libvdwxc support ``                                                        |
| [`f740da26`](https://github.com/NixOS/nixpkgs/commit/f740da26ec7f8497f15e89c621e70fab2f7038d5) | `` umpire: init at 2023.06.0 ``                                                                    |
| [`c8070c2b`](https://github.com/NixOS/nixpkgs/commit/c8070c2b3235cab9cb349cc488044be9940fee4f) | `` gpaw: 23.9.1 -> 24.1.0 ``                                                                       |
| [`f76668b7`](https://github.com/NixOS/nixpkgs/commit/f76668b7862cd4b7acdfa25a5210f5a59c14b55a) | `` telegraf: 1.29.2 -> 1.29.3 ``                                                                   |
| [`be1ced46`](https://github.com/NixOS/nixpkgs/commit/be1ced463b47bc7ce248842a58709194b063f5e5) | `` tmuxPlugins.rose-pine: init at unstable-2024-01-08 (#282379) ``                                 |
| [`3a7f143a`](https://github.com/NixOS/nixpkgs/commit/3a7f143a4fad72c96b742aff5c548815be297d54) | `` bpftrace: 0.20.0 -> 0.20.1 ``                                                                   |
| [`0f4ac829`](https://github.com/NixOS/nixpkgs/commit/0f4ac829080fdad7b07522510005424a00608bf2) | `` kubergrunt: 0.14.0 -> 0.14.1 ``                                                                 |
| [`49b912ae`](https://github.com/NixOS/nixpkgs/commit/49b912ae5aa2a86de2a96df50f9b31624bf58533) | `` exploitdb: 2024-01-24 -> 2024-01-30 ``                                                          |
| [`0f34032f`](https://github.com/NixOS/nixpkgs/commit/0f34032f5a31b46da08126c9ccec16ffaab964fe) | `` nixos/plasma5: install missing style plugins ``                                                 |
| [`a26715f4`](https://github.com/NixOS/nixpkgs/commit/a26715f4dc9a1597e9cff8fc97217a7da8576241) | `` files-cli: 2.12.24 -> 2.12.25 ``                                                                |
| [`f9e2a6f0`](https://github.com/NixOS/nixpkgs/commit/f9e2a6f011b3724892c34a2e46152b4085ca4b2e) | `` vdrPlugins.markad: 3.4.5 -> 3.4.6 ``                                                            |
| [`c1702947`](https://github.com/NixOS/nixpkgs/commit/c1702947d3b469155dbd8d834b2706dd74df4ddb) | `` go-containerregistry: 0.18.0 -> 0.19.0 ``                                                       |
| [`c026ffdd`](https://github.com/NixOS/nixpkgs/commit/c026ffdd2c8678fc29b79fd5cc5cf35406b3967f) | `` firewalld-gui: 2.1.0 -> 2.1.1 ``                                                                |
| [`11796cb2`](https://github.com/NixOS/nixpkgs/commit/11796cb2b394b2cad4eae44c48f194913ce8182c) | `` python312Packages.mkdocs-material: 9.4.14 -> 9.5.6 ``                                           |
| [`3aa7cbf2`](https://github.com/NixOS/nixpkgs/commit/3aa7cbf2bf7d1246ba5994b582c794ced1ddc0ea) | `` gotify-desktop: 1.3.2 -> 1.3.3 ``                                                               |
| [`0dcd2ddd`](https://github.com/NixOS/nixpkgs/commit/0dcd2dddfedb21bf28f30f7bb7b04314850eada4) | `` atlassian-jira: 9.11.1 -> 9.13.0 ``                                                             |
| [`cb5f7434`](https://github.com/NixOS/nixpkgs/commit/cb5f74341e7173d0bf54b18870873dc6391d8308) | `` gup: 0.8.4 -> 0.9.0 ``                                                                          |
| [`434dd13b`](https://github.com/NixOS/nixpkgs/commit/434dd13b25bfe1db97a7bb32cf772f3493416bc3) | `` psst: unstable-2024-01-12 -> unstable-2024-01-28 ``                                             |
| [`5a21941a`](https://github.com/NixOS/nixpkgs/commit/5a21941adf8f250b298cc4a3c3edbb8aee8a60cb) | `` mopac: 22.1.0 -> 22.1.1 ``                                                                      |
| [`9e5b7b2c`](https://github.com/NixOS/nixpkgs/commit/9e5b7b2ceb959a526f78e42f7d6719780c31c4f8) | `` treewide: drop LLVM10 ``                                                                        |
| [`b8669014`](https://github.com/NixOS/nixpkgs/commit/b866901424b140f55d999cc4b4defaca678db4a9) | `` fanbox-dl: 0.17.0 -> 0.18.2 ``                                                                  |
| [`fc971188`](https://github.com/NixOS/nixpkgs/commit/fc9711886a804622ec571cdab83adcd2d0bee6fd) | `` simdutf: 4.0.8 -> 4.0.9 ``                                                                      |
| [`d4da9f46`](https://github.com/NixOS/nixpkgs/commit/d4da9f464de3c074f40964570ac3764139222de2) | `` keycloak: 23.0.4 -> 23.0.5 ``                                                                   |
| [`62442f89`](https://github.com/NixOS/nixpkgs/commit/62442f89fbe2e00f1d5fa643e8cd1923832ea735) | `` simdjson: 3.6.3 -> 3.6.4 ``                                                                     |
| [`07ba9122`](https://github.com/NixOS/nixpkgs/commit/07ba912223ee26bd59c2be251050c071c6906553) | `` fbset: init at 2.1 ``                                                                           |
| [`89d63bd5`](https://github.com/NixOS/nixpkgs/commit/89d63bd5a71bfb9e97bac966da4af04b9c8ec8b2) | `` azure-storage-azcopy: 10.22.2 -> 10.23.0 ``                                                     |
| [`1e7dc0e1`](https://github.com/NixOS/nixpkgs/commit/1e7dc0e1b83e50a5ad8e108d417cf59ac6e9d501) | `` pkgs.writers: fix type in description for writeHaskellBin ``                                    |
| [`703a085c`](https://github.com/NixOS/nixpkgs/commit/703a085c0af81e956d0c2cde2197d0984095992f) | `` pkgs.writers: tests for lua ruby, and remove failed tests because of external package errors `` |
| [`f6e0ee55`](https://github.com/NixOS/nixpkgs/commit/f6e0ee5545889996bf926bd6c726084b72aca22e) | `` pkgs.writers: remove tests that dont work anymore and add comments tracking issues ``           |
| [`05ad04bd`](https://github.com/NixOS/nixpkgs/commit/05ad04bdd339da27b207fec7157e7701e881a36e) | `` pkgs.writers add snu, lua and ruby ``                                                           |
| [`5469f6fa`](https://github.com/NixOS/nixpkgs/commit/5469f6fa555b3c5df4c70c908fa9f7910745d570) | `` cargo-bisect-rustc: 0.6.7 -> 0.6.8 ``                                                           |
| [`d14fb68a`](https://github.com/NixOS/nixpkgs/commit/d14fb68aabe758248d496e5f76c95d73731aae56) | `` unciv: drop envLibPath on darwin ``                                                             |
| [`618a4945`](https://github.com/NixOS/nixpkgs/commit/618a4945cf34672c70769760c138a840fbd070ab) | `` unciv: 4.9.19 -> 4.10.4 ``                                                                      |