### PR TITLE
chore(flake/nixpkgs): `bc6d119b` -> `32682290`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1709228265,
-        "narHash": "sha256-smzkHvYpuOQ0h0b7prfyRtOHIDnmxuTiuenQ9hV2PZM=",
+        "lastModified": 1764505699,
+        "narHash": "sha256-F6hwfLIZ7aeW2JI11EkuUNmybxqwNCYlEw9qCdAjGRs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bc6d119bd0615780470db760bc2cb24ee4583102",
+        "rev": "3268229081495e937b6ffaf6b7619445426cfeed",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                   |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
| [`24943fa7`](https://github.com/NixOS/nixpkgs/commit/24943fa78de44cc869ce611635ac95bec4c99313) | `` neothesia: pin ffmpeg to `ffmpeg_7` ``                                                 |
| [`2ff88bd8`](https://github.com/NixOS/nixpkgs/commit/2ff88bd8d9e54f5e382747814dc126f0f707b99c) | `` python3Packages.alexapy: 1.29.10 -> 1.29.11 ``                                         |
| [`c87fe13c`](https://github.com/NixOS/nixpkgs/commit/c87fe13cb4bd74511a6155c5e9f99ad9df7cb1e6) | `` zig-vim: source from codeberg; move to non-generated ``                                |
| [`d1de0fd0`](https://github.com/NixOS/nixpkgs/commit/d1de0fd08428c07c1fce45e6c351ac8a2c00e0f8) | `` hyprls: 0.10.0 -> 0.11.0 ``                                                            |
| [`911b841b`](https://github.com/NixOS/nixpkgs/commit/911b841b1d850e7d8b75b6279307d614ca9facbc) | `` tomat: enable completion and install man pages ``                                      |
| [`4a16341a`](https://github.com/NixOS/nixpkgs/commit/4a16341a0079761d1cbbdcc35d91777022440f85) | `` local-content-share: 35 -> 36 ``                                                       |
| [`e73e63e2`](https://github.com/NixOS/nixpkgs/commit/e73e63e2a333151e83faa541710b3f992c78c1eb) | `` vimPlugins.avante-nvim: 0.0.27-unstable-2025-11-12 -> 0.0.27-unstable-2025-11-28 ``    |
| [`b4ecb446`](https://github.com/NixOS/nixpkgs/commit/b4ecb446df366f9e7c3a5ff9777700bf3da266e8) | `` python3Packages.levenshtein: 0.27.1 -> 0.27.3 ``                                       |
| [`e6ba17d3`](https://github.com/NixOS/nixpkgs/commit/e6ba17d3ede90de7e5fa82e2cdd9bed27971fd93) | `` python3Packages.levenshtein: rename owner ``                                           |
| [`6ae51273`](https://github.com/NixOS/nixpkgs/commit/6ae51273dda680f7d2874a31ffc26aede3d890e8) | `` gpio-utils: fix makeFlags ``                                                           |
| [`e5167118`](https://github.com/NixOS/nixpkgs/commit/e516711808d97542437788a748920c22641f15d1) | `` k6: 1.4.0 -> 1.4.2 ``                                                                  |
| [`e923fe91`](https://github.com/NixOS/nixpkgs/commit/e923fe910fce020ef04a613308d50fb038336664) | `` discord-screenaudio: drop ``                                                           |
| [`a8ea7b38`](https://github.com/NixOS/nixpkgs/commit/a8ea7b38dac6de7fd22d4f0c102f4f4cdb13028d) | `` nodePackages: update docs to discourage adding new packages ``                         |
| [`7bf3aa9d`](https://github.com/NixOS/nixpkgs/commit/7bf3aa9d0da46f585c58f818bd718f116ca78128) | `` doc/javascript: move nodePackages information back to README.md ``                     |
| [`fd3a8edd`](https://github.com/NixOS/nixpkgs/commit/fd3a8eddcb44829c3e5aded7d768e0f7b27fb2f6) | `` nixos/miniflux: don't require DATABASE_URL if not createDatabaseLocally ``             |
| [`0085dba6`](https://github.com/NixOS/nixpkgs/commit/0085dba62a358855d5188efef7a4c6a919bd840b) | `` hello-go: bump go version ``                                                           |
| [`3da9c75c`](https://github.com/NixOS/nixpkgs/commit/3da9c75c4991a89786d90d72481d689d1db33d82) | `` vacuum-tube: 1.4.0 -> 1.4.1 ``                                                         |
| [`538f4cd8`](https://github.com/NixOS/nixpkgs/commit/538f4cd84cb0956934fb9b6ef664e5f7b8f97571) | `` python3Packages.xonsh: 0.19.9 -> 0.20.0 ``                                             |
| [`57d0e190`](https://github.com/NixOS/nixpkgs/commit/57d0e1900d5861ec26ddf7d9e0ae1bc05a371a84) | `` svg2tikz: 3.3.3 -> 3.3.4 ``                                                            |
| [`f0a64c31`](https://github.com/NixOS/nixpkgs/commit/f0a64c3159ce0b921bdc3c4396077c3f6213db3d) | `` zed-editor: 0.214.6 -> 0.214.7 ``                                                      |
| [`cb97018c`](https://github.com/NixOS/nixpkgs/commit/cb97018c944e1e6bb906d017a993fbcc97d18b60) | `` vscode: 1.106.2 -> 1.106.3 ``                                                          |
| [`3204cf8e`](https://github.com/NixOS/nixpkgs/commit/3204cf8ee6c32aec9c1e8a02619d31c729c3948a) | `` terraform-providers.hashicorp_google: 7.11.0 -> 7.12.0 ``                              |
| [`94ebecdc`](https://github.com/NixOS/nixpkgs/commit/94ebecdc5529b150330796e4d7ce3d766ce38355) | `` python3Packages.gftools: 0.9.97 -> 0.9.98 ``                                           |
| [`90c3994f`](https://github.com/NixOS/nixpkgs/commit/90c3994f3aedf41d668715de634ddd1967359187) | `` pythonPackages.dvc: fix typo ``                                                        |
| [`acff7730`](https://github.com/NixOS/nixpkgs/commit/acff77306f17481e7c3f99e35ebed87ea7a0e447) | `` bottles: add support for wine-wayland ``                                               |
| [`2f378e71`](https://github.com/NixOS/nixpkgs/commit/2f378e713cf473b5ae3494784c66b6fec6910867) | `` libdaq: 3.0.22 -> 3.0.23 ``                                                            |
| [`a524af41`](https://github.com/NixOS/nixpkgs/commit/a524af41d3fe137486fdccd8901d2e148b66eb75) | `` python3Packages.speechbrain: disable on Darwin due to broken sentencepiece ``          |
| [`471f2f23`](https://github.com/NixOS/nixpkgs/commit/471f2f237e0238a2464fbe8d4edc2576a16f06de) | `` python3Packages.bx-py-utils: 113 -> 114 ``                                             |
| [`8d072625`](https://github.com/NixOS/nixpkgs/commit/8d0726258c39e32bab8a32001b07451ce1743167) | `` github-backup: 0.51.3 -> 0.52.0 ``                                                     |
| [`4d8e1ac5`](https://github.com/NixOS/nixpkgs/commit/4d8e1ac56ede4cb651017afb871854a555e8f210) | `` hatch: 1.14.2 -> 1.16.1 ``                                                             |
| [`e2268b7f`](https://github.com/NixOS/nixpkgs/commit/e2268b7f8cc67a478793502b0dc62feb1aa897f3) | `` python3Packages.gluonts: fetch patch to fix failing test ``                            |
| [`773490de`](https://github.com/NixOS/nixpkgs/commit/773490de39afb75689ff5bc1bb75247b97e160f8) | `` fastmail-desktop: 1.0.4 -> 1.0.5 ``                                                    |
| [`dcd19686`](https://github.com/NixOS/nixpkgs/commit/dcd19686f08ed9629aab49e352f0deed2ea8f4b2) | `` python3Packages.niapy: 2.6.0 -> 2.6.1 ``                                               |
| [`cc5d9567`](https://github.com/NixOS/nixpkgs/commit/cc5d9567155fbbdda0287db7ebd5cd4d4ece7aef) | `` rumdl: 0.0.181 -> 0.0.185 ``                                                           |
| [`46df0ee9`](https://github.com/NixOS/nixpkgs/commit/46df0ee9d80afea2e9b56d6dcdcf8a6a46805e9a) | `` zeroad{-unwrapped,-data}: fetch source via https ``                                    |
| [`51afe72e`](https://github.com/NixOS/nixpkgs/commit/51afe72e527df3167884baa0db1e04cee28e6d8e) | `` nixos/doc/rl-2511: move nixpkgs entries to nixpkgs manual ``                           |
| [`0eea1c75`](https://github.com/NixOS/nixpkgs/commit/0eea1c75d3f0223ad6e25a4fc8d7a3224d52936f) | `` nixos/doc/rl-2511: cleanup ``                                                          |
| [`aa528432`](https://github.com/NixOS/nixpkgs/commit/aa528432f4f5bf41ecf3225045ffeb09cb1d447a) | `` giac: disable libc++ hardening ``                                                      |
| [`931c0373`](https://github.com/NixOS/nixpkgs/commit/931c0373d0d85adfd8954922d7ba8d53028763d1) | `` doc/rl-2511: move nixos entries to nixos release notes ``                              |
| [`c3299c7b`](https://github.com/NixOS/nixpkgs/commit/c3299c7b603eb6f03eaf393559a5389eb7d0cf30) | `` home-assistant-custom-components.volkswagencarnet: 5.1.4 -> 5.1.7 ``                   |
| [`29a3916f`](https://github.com/NixOS/nixpkgs/commit/29a3916fd891acbbb34a90eda2b99e425cd1685f) | `` python3Packages.volkswagencarnet: 5.1.3 -> 5.1.6 ``                                    |
| [`1df3a50d`](https://github.com/NixOS/nixpkgs/commit/1df3a50dbbb658821d411033e67ea5ad8f06d342) | `` tcp_wrappers: 7.6.q-33 -> 7.6.q-36 and fetch patches from salsa ``                     |
| [`1dea6dd1`](https://github.com/NixOS/nixpkgs/commit/1dea6dd1d1f4401fae5510ccbfcc446fa4305f8e) | `` libcpr: 1.13.0 -> 1.14.1 ``                                                            |
| [`4b1e2882`](https://github.com/NixOS/nixpkgs/commit/4b1e2882e4e2c55fcc207d965728f01000f5e040) | `` tigerbeetle: 0.16.65 -> 0.16.66 ``                                                     |
| [`8f75ca3d`](https://github.com/NixOS/nixpkgs/commit/8f75ca3dcc7fb16ae6b2ff7849fb2b6e0b8ba484) | `` qutebrowser: fix loading libwayland-client ``                                          |
| [`18bcb6c3`](https://github.com/NixOS/nixpkgs/commit/18bcb6c30e981b520e99a35af8013219c868c12d) | `` xenia-canary: 0-unstable-2025-11-22 -> 0-unstable-2025-11-29 ``                        |
| [`b9f19184`](https://github.com/NixOS/nixpkgs/commit/b9f19184d8f0260dc94d48000dcb0f1f5c02f9ee) | `` doc/rl-2511: cleanup ``                                                                |
| [`b91a5cea`](https://github.com/NixOS/nixpkgs/commit/b91a5cea24c60e6e9458337df23f2a30834c554f) | `` binserve: drop ``                                                                      |
| [`dbacbfb1`](https://github.com/NixOS/nixpkgs/commit/dbacbfb117bd9db796e1fb72ec59ba94bf1ee428) | `` binserve: mark vulnerable ``                                                           |
| [`ec479bf5`](https://github.com/NixOS/nixpkgs/commit/ec479bf5ec4cb7859d85a1184d025dc61e597ee6) | `` python3Packages.django-filer: add meta.changelog ``                                    |
| [`b38ec51b`](https://github.com/NixOS/nixpkgs/commit/b38ec51ba5df20692c924847b004cff80689c590) | `` python3Packages.django-filer: remove disabled ``                                       |
| [`7de00d15`](https://github.com/NixOS/nixpkgs/commit/7de00d157b7f2de5af4af217725a84e7401381ee) | `` sloc: repackage using buildNpmPackage ``                                               |
| [`64aaa1cf`](https://github.com/NixOS/nixpkgs/commit/64aaa1cf0bff91ef4f37b20a6e7243863fb8a4f1) | `` pure-maps: 3.4.1 -> 3.4.2 ``                                                           |
| [`3ce8bd1c`](https://github.com/NixOS/nixpkgs/commit/3ce8bd1c7bebba257b6c4ee38b30841f5a7d66b5) | `` radicale: 3.5.8 -> 3.5.9 ``                                                            |
| [`5e77878c`](https://github.com/NixOS/nixpkgs/commit/5e77878c7961538798a397f96d129e293c626865) | `` libretro.beetle-psx: 0-unstable-2025-11-14 -> 0-unstable-2025-11-28 ``                 |
| [`6ad70c17`](https://github.com/NixOS/nixpkgs/commit/6ad70c17467a2ab1c242d73589bef2341bfd2ef0) | `` nixos/anki-sync-server: fix NixOS test ``                                              |
| [`38597954`](https://github.com/NixOS/nixpkgs/commit/385979548c9b9c351137f8915ed5178676840f12) | `` libirc: fix build for cmake4 ``                                                        |
| [`9358219a`](https://github.com/NixOS/nixpkgs/commit/9358219a8e6aed7a8b0c67f8405e5fd132bc9db4) | `` davmail: Use `nix-update-script` for package updates ``                                |
| [`3cffb9cc`](https://github.com/NixOS/nixpkgs/commit/3cffb9cc70a4c54851f3765d2890f453b47ac488) | `` maintainers: remove rasendubi from maintainers ``                                      |
| [`b6ace79d`](https://github.com/NixOS/nixpkgs/commit/b6ace79de1bd5cc43474763ce73f91085bec88ee) | `` root: 6.36.04 -> 6.38.00 ``                                                            |
| [`ea34eac6`](https://github.com/NixOS/nixpkgs/commit/ea34eac61bf8d9463b03d74bd9559f9f3d759972) | `` ceph: remove unused dependency from httpcore ``                                        |
| [`13da7723`](https://github.com/NixOS/nixpkgs/commit/13da77230e792635e01de205c8fbdec55b5f27d9) | `` protonvpn-gui: migrate to pkgs/by-name ``                                              |
| [`a2620687`](https://github.com/NixOS/nixpkgs/commit/a26206874914ed3b751a36f491ea23eacb88bf8e) | `` komac: 2.13.0 -> 2.14.0 ``                                                             |
| [`5649ce33`](https://github.com/NixOS/nixpkgs/commit/5649ce33cb41056062cde1e03ff53b0dbb07ca1b) | `` python3Packages.langchain-classic: disable bulk update ``                              |
| [`4f5fe642`](https://github.com/NixOS/nixpkgs/commit/4f5fe642fa587599c088d41115e73f9923468703) | `` arandr: the license is GPL-3.0-or-later ``                                             |
| [`35b537a7`](https://github.com/NixOS/nixpkgs/commit/35b537a74fd67c4f3f889bc1d15d74d655de30bf) | `` arandr: don't double-wrap executables ``                                               |
| [`51dcf3f7`](https://github.com/NixOS/nixpkgs/commit/51dcf3f7981312cbc49580fcbb70de1698e93472) | `` yarn-berry: 4.11.0 -> 4.12.0 ``                                                        |
| [`4dd10767`](https://github.com/NixOS/nixpkgs/commit/4dd10767bd2d0ca54b2b2f6784fea700dc1d56af) | `` arandr: use pyproject format ``                                                        |
| [`e053936e`](https://github.com/NixOS/nixpkgs/commit/e053936e710c7a42600fb5b03c2818845ba5d872) | `` trealla: 2.85.9 -> 2.86.5 ``                                                           |
| [`e95261d8`](https://github.com/NixOS/nixpkgs/commit/e95261d831c7ebd2d171e764ef244e576b92ebf8) | `` mimir: 3.0.0 -> 3.0.1 ``                                                               |
| [`0c268328`](https://github.com/NixOS/nixpkgs/commit/0c268328728d8040ba50049ff91b955236a21e2c) | `` github-copilot-cli: 0.0.362 -> 0.0.365 ``                                              |
| [`2fa54cab`](https://github.com/NixOS/nixpkgs/commit/2fa54cab6e6f21474162727707f156fafa388bcb) | `` python3Packages.textual: 6.6.0 -> 6.7.0 ``                                             |
| [`dee210fe`](https://github.com/NixOS/nixpkgs/commit/dee210fef9fbdb1ab58b53f575a31db24d2c1c1a) | `` rusthound-ce: init at 2.4.4 ``                                                         |
| [`6a26d0bf`](https://github.com/NixOS/nixpkgs/commit/6a26d0bf1919279e146f085d8c699d34e3f3035f) | `` incus: 6.19.0 -> 6.19.1 ``                                                             |
| [`70d22bc0`](https://github.com/NixOS/nixpkgs/commit/70d22bc07da86cf8298480a3e4a54def640919f8) | `` tofu-ls: 0.2.0 -> 0.3.0 ``                                                             |
| [`1e72a6b3`](https://github.com/NixOS/nixpkgs/commit/1e72a6b3bc123a85d301792f71026dbdf06693f1) | `` calligraplan: fix build for CMake 4 ``                                                 |
| [`084c030f`](https://github.com/NixOS/nixpkgs/commit/084c030f300b6d62fa4b18651876bc2f93777115) | `` ruffle: 0.2.0-nightly-2025-11-22 -> 0.2.0-nightly-2025-11-29 ``                        |
| [`f7992c4b`](https://github.com/NixOS/nixpkgs/commit/f7992c4ba22cbcb58e00d9c2d7d05a5122af89b4) | `` python3Packages.django-filer: 3.3.3 -> 3.4.1 ``                                        |
| [`178b0771`](https://github.com/NixOS/nixpkgs/commit/178b07716d2928df24c575966e0d81ad7aab53ff) | `` nixos/nextcloud: Fix services.nextcloud.settings.mail_smtpstreamoptions option type `` |
| [`71cb937c`](https://github.com/NixOS/nixpkgs/commit/71cb937c51f49554692593d76ccdccf41db42e56) | `` multipass: remove unmaintained package and module ``                                   |
| [`ca193731`](https://github.com/NixOS/nixpkgs/commit/ca193731b135b7742017b240bdfc1936890e2d23) | `` nak: 0.16.2 -> 0.17.1 ``                                                               |
| [`8e2d270a`](https://github.com/NixOS/nixpkgs/commit/8e2d270ae2748021d94f25b4281292ae4e713813) | `` files-cli: 2.15.152 -> 2.15.156 ``                                                     |
| [`3b48cad4`](https://github.com/NixOS/nixpkgs/commit/3b48cad40e59ccde15a02fd8f3ce5fa76786afed) | `` bruno: 2.14.2 -> 2.15.0 ``                                                             |
| [`2447d64d`](https://github.com/NixOS/nixpkgs/commit/2447d64db0aebb0fbd05ab5f1d4901e95f2415f8) | `` libcpr: 1.12.0 -> 1.13.0 ``                                                            |
| [`1b67ef95`](https://github.com/NixOS/nixpkgs/commit/1b67ef952a72dfc04c59ab492df4942aa9c89ecf) | `` libcpr: merge duplicate cpr package ``                                                 |
| [`76bc0737`](https://github.com/NixOS/nixpkgs/commit/76bc0737b61f93d608fdee9d9c1d65bee310d24a) | `` gat: 0.25.6 -> 0.25.7 ``                                                               |
| [`ae78dd0d`](https://github.com/NixOS/nixpkgs/commit/ae78dd0d1817eba208e48285ff078ddb30afd5d8) | `` mslicer: 0.3.0 -> 0.4.0 ``                                                             |
| [`9adb0847`](https://github.com/NixOS/nixpkgs/commit/9adb08474c725d3a4176b34e1f51b6a22d78cac0) | `` python3Packages.cassandra-driver: 3.29.2 -> 3.29.3 ``                                  |