### PR TITLE
chore(flake/gitignore): `637db329` -> `cb5e3fdc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "lastModified": 1762808025,
+        "narHash": "sha256-XmjITeZNMTQXGhhww6ed/Wacy2KzD6svioyCX7pkUu4=",
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "rev": "cb5e3fdca1de58ccbc3ef53de65bd372b48f567c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                     | Message                                                        |
| ---------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`cd6e4278`](https://github.com/hercules-ci/gitignore.nix/commit/cd6e427877711d2dc840447a461cceb19ebfb7cb) | `` Make regression-config-with-store-path work ``              |
| [`ef919372`](https://github.com/hercules-ci/gitignore.nix/commit/ef9193727672eb2776c552195efb5a0a53c35b82) | `` Fix guardNonEmptyString ``                                  |
| [`44b4626e`](https://github.com/hercules-ci/gitignore.nix/commit/44b4626e81d01f2caa3a6a5a4488017622fdb42e) | `` WIP: add regression test for #71 ``                         |
| [`81c6af25`](https://github.com/hercules-ci/gitignore.nix/commit/81c6af2553a6c6b3551941018cc4b35a85de4bbf) | `` fix comment ``                                              |
| [`61ddc300`](https://github.com/hercules-ci/gitignore.nix/commit/61ddc300c1ee8d1f7f48905e4d299fa8d88fcfaf) | `` discard string context of git config's core.excludesFile `` |